### PR TITLE
Fix: UUID field support

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -36,6 +36,7 @@ class DatabaseFeatures(BasePGDatabaseFeatures):
     supports_column_check_constraints = False
     can_distinct_on_fields = False
     allows_group_by_selected_pks = False
+    has_native_uuid_field = False
 
 
 class DatabaseOperations(BasePGDatabaseOperations):

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -20,7 +20,7 @@ Setup development environment
 * Requires supported Python version
 * do setup under django-redshift-backend.git repository root as::
 
-    $ pip install -U pip setuptools wheel setuotools_scm
+    $ pip install -U pip setuptools wheel setuptools_scm
     $ pip install -r dev-requires.txt
 
 Testing

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -70,6 +70,19 @@ class ModelTest(unittest.TestCase):
         sql = norm_sql(compiler.as_sql()[0])
         self.assertEqual(sql, expected_dml_annotate)
 
+    def test_insert_uuid_field(self):
+        import uuid
+        from django.db.models import sql
+        from testapp.models import TestModel
+        obj = TestModel(uuid=uuid.uuid4())
+        q = sql.InsertQuery(obj)
+        q.insert_values(obj._meta.local_fields, [obj])
+        statements = q.get_compiler('default').as_sql()
+        # uuid is the last field of TestModel
+        uuid_insert_value = statements[0][1][-1]
+        # the Python value for insertion must be a string of length 32
+        self.assertEqual(type(uuid_insert_value), str)
+        self.assertEqual(len(uuid_insert_value), 32)
 
 class MigrationTest(unittest.TestCase):
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -80,7 +80,7 @@ class ModelTest(unittest.TestCase):
         statements = q.get_compiler('default').as_sql()
         # uuid is the last field of TestModel
         uuid_insert_value = statements[0][1][-1]
-        # the Python value for insertion must be a string of length 32
+        # the Python value for insertion must be a string whose length is 32
         self.assertEqual(type(uuid_insert_value), str)
         self.assertEqual(len(uuid_insert_value), 32)
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -84,6 +84,7 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(type(uuid_insert_value), str)
         self.assertEqual(len(uuid_insert_value), 32)
 
+
 class MigrationTest(unittest.TestCase):
 
     def check_model_creation(self, model, expected_ddl):


### PR DESCRIPTION
Subject: Fix for the `UUIDField` support

### Feature or Bugfix
- Bugfix

### Purpose
- This PR should fix the bug I reported [here](https://github.com/jazzband/django-redshift-backend/issues/53) when I tried to insert a value for a `UUIDField` in Redshift.
- I also added a test for the insertion of a `UUIDField`. We should check that the type of the Python argument is `str` (as opposed to `uuid.UUID`) and its length is 32.

### Detail
- Fix the Python value of `UUIDField` when used in Redshift (should be a `str`, _i.e._ the value of `UUID.hex`)
- Fix a typo in the documentation

### Relates
- Fixes #53 
- See [here](https://github.com/django/django/blob/master/django/db/models/fields/__init__.py#L2316) for why this fix works
