### PR TITLE
Add support for Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 cache: pip
 env:
   - DJANGO="2.0"
+  - DJANGO="2.1"
   - DJANGO="1.11"
 install:
 - travis_retry pip install tox-travis
@@ -16,6 +17,8 @@ script:
 jobs:
   exclude:
     - env: DJANGO="2.0"
+      python: '2.7'
+    - env: DJANGO="2.1"
       python: '2.7'
   include:
   - stage: deploy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ General:
 
 New Features:
 
-* Nothing
+* #56 Support Django 2.1.
 
 Bug Fixes:
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -94,8 +94,7 @@ class DatabaseOperations(BasePGDatabaseOperations):
             # Redshift doesn't support DISTINCT ON
             raise NotSupportedError('DISTINCT ON fields is not supported '
                                       'by this database backend')
-        else:
-            return 'DISTINCT'
+        return super(self, DatabaseOperations).distinct_sql(*args)
 
 
 def _related_non_m2m_objects(old_field, new_field):

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -88,13 +88,13 @@ class DatabaseOperations(BasePGDatabaseOperations):
             value = uuid.UUID(value)
         return value
 
-    def distinct_sql(self, *args):
-        if args:
+    def distinct_sql(self, fields, *args):
+        if fields:
             # https://github.com/jazzband/django-redshift-backend/issues/14
             # Redshift doesn't support DISTINCT ON
             raise NotSupportedError('DISTINCT ON fields is not supported '
                                       'by this database backend')
-        return super(self, DatabaseOperations).distinct_sql(*args)
+        return super(DatabaseOperations, self).distinct_sql(fields, *args)
 
 
 def _related_non_m2m_objects(old_field, new_field):

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -22,6 +22,7 @@ from django.db.backends.postgresql_psycopg2.base import (
     DatabaseCreation as BasePGDatabaseCreation,
     DatabaseIntrospection,
 )
+from django.db.utils import NotSupportedError
 
 from django_redshift_backend.distkey import DistKey
 
@@ -64,7 +65,7 @@ class DatabaseOperations(BasePGDatabaseOperations):
         return cursor.fetchone()[0]
 
     def for_update_sql(self, nowait=False):
-        raise NotImplementedError(
+        raise NotSupportedError(
             'SELECT FOR UPDATE is not implemented for this database backend')
 
     def deferrable_sql(self):
@@ -87,11 +88,11 @@ class DatabaseOperations(BasePGDatabaseOperations):
             value = uuid.UUID(value)
         return value
 
-    def distinct_sql(self, fields):
-        if fields:
+    def distinct_sql(self, *args):
+        if args:
             # https://github.com/jazzband/django-redshift-backend/issues/14
             # Redshift doesn't support DISTINCT ON
-            raise NotImplementedError('DISTINCT ON fields is not supported '
+            raise NotSupportedError('DISTINCT ON fields is not supported '
                                       'by this database backend')
         else:
             return 'DISTINCT'
@@ -131,7 +132,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         return
 
     def _create_index_sql(self, model, fields, suffix="", sql=None):
-        raise NotImplementedError("Redshift doesn't support INDEX")
+        raise NotSupportedError("Redshift doesn't support INDEX")
 
     def create_model(self, model):
         """

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'Environment :: Plugins',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{27,35,36}-dj111,
     py{35,36}-dj20,
+    py{35,36,37}-dj21,
     flake8,
     isort,
     readme
@@ -17,11 +18,13 @@ python =
 DJANGO =
     1.11: dj111
     2.0: dj20
+    2.1: dj21
 
 [testenv]
 deps =
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     djmaster: https://github.com/django/django/archive/master.tar.gz
     -rtest-requires.txt
 setenv =


### PR DESCRIPTION
Subject: Add support for Django 2.1

### Feature or Bugfix
<!-- please choose -->
- Feature
- ~~Bugfix~~

### Purpose

- Fixes #49 
- Some changes for that backward impompatible changes

### Detail

- [To adhere to PEP 249, exceptions where a database doesn’t support a feature are changed from `NotImplementedError` to `django.db.NotSupportedError`.](https://docs.djangoproject.com/en/2.1/releases/2.1/#database-backend-api)
- [`DatabaseOperations.distinct_sql()` now requires an additional params argument and returns a tuple of SQL and parameters instead of a SQL string.](https://docs.djangoproject.com/en/2.1/releases/2.1/#database-backend-api) Thank you @jdlourenco

### Relates
- #49 
- https://docs.djangoproject.com/en/2.1/releases/2.1/

