### PR TITLE
Support query_group for WLM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 CHANGES
 =======
 
+1.0.1
+-----
+
+New Features:
+
+* Support `query_group` options for `Work Load Management`_
+
+.. _Work Load Management: https://docs.aws.amazon.com/redshift/latest/dg/cm-c-implementing-workload-management.html
+
 1.0.0 (2019/01/29)
 ------------------
 

--- a/doc/basic.rst
+++ b/doc/basic.rst
@@ -25,8 +25,20 @@ ENGINE for DATABASES is 'django_redshift_backend'. You can set the name in your 
            'PASSWORD': '<your database password>',
            'HOST': '<your database hostname>',
            'PORT': '5439',
+           'OPTIONS': {
+               'query_group': 'webapp',
+           },
        }
    }
+
+
+OPTIONS
+-------
+
+- ``query_group``: Set query_group_ to use `Work Load Management`_
+
+.. _query_group: https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html
+.. _Work Load Management: https://docs.aws.amazon.com/redshift/latest/dg/cm-c-implementing-workload-management.html
 
 For more information, please refer :doc:`refs`.
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -9,6 +9,9 @@ DATABASES = {
         'PASSWORD': 'password',
         'HOST': 'localhost',
         'PORT': '5439',
+        'OPTIONS': {
+            'query_group': 'webapp',
+        },
     }
 }
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import mock
 import unittest
 
 from django.db import connections
@@ -19,6 +20,20 @@ class DatabaseWrapperTest(unittest.TestCase):
     def test_load_redshift_backend(self):
         db = connections['default']
         self.assertIsNotNone(db)
+
+    def test_query_group(self):
+        db = connections['default']
+        self.assertIsNotNone(db)
+
+        db.get_connection_params()
+        self.assertEqual('webapp', db.query_group)
+
+        db.connection = mock.Mock()
+        db.ensure_timezone = mock.Mock()
+        db.force_debug_cursor = True
+
+        db.init_connection_state()
+        self.assertEqual(1, len(db.queries_log))
 
 
 expected_ddl_normal = norm_sql(


### PR DESCRIPTION
Subject: Set `query_group` for [WLM](https://docs.aws.amazon.com/redshift/latest/dg/cm-c-implementing-workload-management.html)

### Feature or Bugfix
<!-- please choose -->
- Feature
- ~~Bugfix~~

### Purpose
- Set [`query_group`](https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html) when create connection

### Detail
- Run `SET query_group TO <specific query group by OPTIONS>`

### Relates
- https://docs.aws.amazon.com/redshift/latest/dg/cm-c-implementing-workload-management.html
- https://docs.aws.amazon.com/redshift/latest/dg/r_query_group.html

