### PR TITLE
Update refs.rst

### DIFF
--- a/doc/refs.rst
+++ b/doc/refs.rst
@@ -76,8 +76,7 @@ settings.DATABASES
 
 :PORT:
    Set your Redshift server port number. Maybe '5439'.
-       }
-   }
+
 
 settings.REDSHIFT_VARCHAR_LENGTH_MULTIPLIER
 -------------------------------------------


### PR DESCRIPTION
In documentation removed curly braces in port description.

Subject: <short purpose of this pull request>

### Feature or Bugfix
- Bugfix

### Purpose
- Just a typo cleanup in documentation

### Detail
In port definition, there were two curly braces: https://django-redshift-backend.readthedocs.io/en/master/refs.html

### Relates


