### PR TITLE
Let users choose between psycopg2 binary or source

### DIFF
--- a/doc/basic.rst
+++ b/doc/basic.rst
@@ -11,6 +11,20 @@ Please install django-redshift-backend with using pip (8.1.1 or later).
 
    $ pip install django-redshift-backend
 
+This backend requires ``psycopg2``, which may be installed from source or wheel (pre-built binaries).
+If you don't want to specify it separately, you may install it using extra:
+
+.. code-block:: bash
+
+   # For pre-built binary
+   $ pip install django-redshift-backend[psycopg2-binary]
+
+   # For the source distribution
+   $ pip install django-redshift-backend[psycopg2]
+
+Please refer to the `psycopg2 documentation`_ for more details on the topic.
+
+.. _psycopg2 documentation: https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
 
 Django settings
 ===============
@@ -29,5 +43,4 @@ ENGINE for DATABASES is 'django_redshift_backend'. You can set the name in your 
    }
 
 For more information, please refer :doc:`refs`.
-
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import os
 
 requires = [
     'django',
-    'psycopg2-binary',
 ]
 
 
@@ -25,6 +24,10 @@ setup(
     description='Redshift database backend for Django',
     long_description=read('README.rst') + read('CHANGES.rst'),
     install_requires=requires,
+    extra_requires={
+        'psycopg2-binary': ['psycopg2-binary'],
+        'psycopg2': ['psycopg2'],
+    },
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Subject: Let users choose between psycopg2 binary or source

### Feature or Bugfix
- Bugfix

### Purpose
On our system we want to install the source version of psycopg2, but because of #60, we are also getting the binary version when we install `django-redshift-backend`.

Adding `extra_requires` to let the use choose which version they want.

Quoting [the psycopg2 documentation](https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary):

> If you are the maintainer of a published package depending on `psycopg2` you shouldn’t use `psycopg2-binary` as a module dependency. **For production use you are advised to use the source distribution**.

### Relates
- https://github.com/jazzband/django-redshift-backend/pull/60

