### PR TITLE
Specify FILTER WHERE syntax not supported

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -39,6 +39,7 @@ class DatabaseFeatures(BasePGDatabaseFeatures):
     can_distinct_on_fields = False
     allows_group_by_selected_pks = False
     has_native_uuid_field = False
+    supports_aggregate_filter_clause = False
 
 
 class DatabaseOperations(BasePGDatabaseOperations):

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -54,6 +54,21 @@ expected_dml_annotate = norm_sql(
     "testapp_testparentmodel"."age"
 ''')
 
+expected_aggregate_filter_emulated = norm_sql(
+    u'''SELECT
+    "testapp_testparentmodel"."id",
+    "testapp_testparentmodel"."age",
+    COUNT(
+        CASE WHEN "testapp_testparentmodel"."age" < %s
+        THEN "testapp_testchildmodel"."id" ELSE NULL END
+    ) AS "cnt"
+    FROM "testapp_testparentmodel"
+    LEFT OUTER JOIN "testapp_testchildmodel"
+    ON ("testapp_testparentmodel"."id" = "testapp_testchildmodel"."parent_id")
+    GROUP BY
+    "testapp_testparentmodel"."id",
+    "testapp_testparentmodel"."age"
+''')
 
 expected_dml_distinct = norm_sql(
     u'''SELECT DISTINCT
@@ -80,6 +95,17 @@ class ModelTest(unittest.TestCase):
         compiler = query.get_compiler(using='default')
         sql = norm_sql(compiler.as_sql()[0])
         self.assertEqual(sql, expected_dml_annotate)
+
+    def test_emulate_aggregate_filter(self):
+        self.maxDiff = None
+        from django.db.models import Count, Q
+        from testapp.models import TestParentModel
+        query = TestParentModel.objects.annotate(
+            cnt=Count('testchildmodel', filter=Q(age__lt=10))
+        ).query
+        compiler = query.get_compiler(using='default')
+        sql = norm_sql(compiler.as_sql()[0])
+        self.assertEqual(sql, expected_aggregate_filter_emulated)
 
     def test_insert_uuid_field(self):
         import uuid


### PR DESCRIPTION
Subject: Redshift doesn't support FILTER WHERE syntax

### Feature or Bugfix
- Bugfix

### Purpose
- This PR just marks supports_aggregate_filter_clause as an unsupported database feature so that the ORM will fallback to CASE statements in conditional aggregation.

### Detail
- Details in the [Django docs for conditional aggregation](https://docs.djangoproject.com/en/2.1/ref/models/conditional-expressions/#conditional-aggregation).

### Relates
- Rebased replacement for #62 

