### PR TITLE
exclude py36-djdev, py37-djdev. use newest python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,12 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9']
-        django-version: ['2.2', '3.0', '3.1', 'dev']
+        django-version: ['2.2', '3.0', '3.1']
+        include:
+          - django-version: 'dev'
+            python-version: '3.8'
+          - django-version: 'dev'
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31,dev}
+    py{36,37,38,39}-dj{22,30,31}
+    py{38,39}-djdev
     flake8
     check
 skipsdist = True
 
 [gh-actions]
 python =
-    3.6: py36, flake8, check
+    3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39
+    3.9: py39, flake8, check
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- exclude djdev-py36 and djdev-py37 testing because djdev (django-4.0) drop support py36 and py37.

### Relates
- https://code.djangoproject.com/ticket/32355
