### PR TITLE
modernize setup.cfg and pyproject.toml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ CHANGES
 General:
 
 * #76 fix test failing on django-dev with py36,py37
+* #77 Mondernize setup.cfg
 
 Bug Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ CHANGES
 General:
 
 * #76 fix test failing on django-dev with py36,py37
-* #77 Mondernize setup.cfg
+* #77 Mondernize setup.cfg and pyproject.toml
 
 Bug Fixes:
 

--- a/dev-requires.txt
+++ b/dev-requires.txt
@@ -2,4 +2,5 @@ setuptools
 wheel
 setuptools_scm
 tox>=3.5
+build
 -e ./

--- a/django_redshift_backend/__init__.py
+++ b/django_redshift_backend/__init__.py
@@ -1,6 +1,14 @@
-from pkg_resources import get_distribution, DistributionNotFound
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    pass
+try:  # py38 or later
+    from importlib.metadata import version, PackageNotFoundError
+    try:
+        __version__ = version("package-name")
+    except PackageNotFoundError:
+        # package is not installed
+        pass
+except ImportError:  # py36, py37
+    from pkg_resources import get_distribution, DistributionNotFound
+    try:
+        __version__ = get_distribution(__name__).version
+    except DistributionNotFound:
+        # package is not installed
+        pass

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -20,7 +20,7 @@ Setup development environment
 * Requires supported Python version
 * do setup under django-redshift-backend.git repository root as::
 
-    $ pip install -U pip setuptools wheel setuptools_scm
+    $ pip install -U pip setuptools
     $ pip install -r dev-requires.txt
 
 Testing
@@ -49,6 +49,14 @@ Pull Request
 **To Be Written**
 
 * https://github.com/jazzband/django-redshift-backend/pulls
+
+
+Build package
+=============
+
+Use build::
+
+   $ build
 
 
 Releasing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,6 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
 [tool.setuptools_scm]
 # this empty section means: use_scm_version=True
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+[tool.setuptools_scm]
+# this empty section means: use_scm_version=True
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = django-redshift-backend
-version = 
 url= https://github.com/jazzband/django-redshift-backend
 author = shimizukawa
 author_email = shimizukawa@gmail.com
@@ -39,6 +38,8 @@ include_package_data = false
 zip_safe = false
 install_requires =
     django
+setup_requires =
+    setuptools_scm
 
 [options.extras_require]
 psycopg2-binary = psycopg2-binary

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,49 @@
+[metadata]
+name = django-redshift-backend
+version = 
+url= https://github.com/jazzband/django-redshift-backend
+author = shimizukawa
+author_email = shimizukawa@gmail.com
+license = Apache Software License
+license_file = LICENSE
+description = Redshift database backend for Django
+long_description = file: README.rst, CHANGES.rst
+long_description_content_type = text/x-rst
+keywords = django, redshift
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Framework :: Django
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
+    Framework :: Django :: 3.1
+    Intended Audience :: Developers
+    Environment :: Plugins
+    Topic :: Software Development :: Libraries :: Python Modules
+project_urls =
+    Documentation = https://django-redshift-backend.readthedocs.io/
+    Release notes = https://django-redshift-backend.readthedocs.io/en/master/changes.html
+    Source = https://github.com/jazzband/django-redshift-backend
+    Tracker = https://github.com/jazzband/django-redshift-backend/issues
+
+[options]
+python_requires = >=3.6, <4
+packages = find:
+include_package_data = false
+zip_safe = false
+install_requires =
+    django
+
+[options.extras_require]
+psycopg2-binary = psycopg2-binary
+psycopg2 = psycopg2
+
 [wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
 from setuptools import setup
 
-setup(
-    setup_requires=['setuptools_scm'],
-    use_scm_version=True,
-)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,50 +1,6 @@
-from setuptools import setup, find_packages
-import os
-
-requires = [
-    'django',
-]
-
-
-def read(filename):
-    fpath = os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
-    with open(fpath) as f:
-        return f.read()
-
+from setuptools import setup
 
 setup(
-    name='django-redshift-backend',
     setup_requires=['setuptools_scm'],
     use_scm_version=True,
-    packages=find_packages(),
-    url='https://github.com/jazzband/django-redshift-backend',
-    license='Apache Software License',
-    author='shimizukawa',
-    author_email='shimizukawa@gmail.com',
-    description='Redshift database backend for Django',
-    long_description=read('README.rst') + read('CHANGES.rst'),
-    long_description_content_type='text/x-rst',
-    install_requires=requires,
-    extra_requires={
-        'psycopg2-binary': ['psycopg2-binary'],
-        'psycopg2': ['psycopg2'],
-    },
-    python_requires='>=3.6, <4',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Framework :: Django',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
-        'Intended Audience :: Developers',
-        'Environment :: Plugins',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
 )


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Move setup.py parameters into setup.cfg

### Detail
- Since setuptools-30.3.0 (8 Dec 2016), almost all parameters can now be written in setup.cfg.

### Relates
- https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html

