### PR TITLE
Compatibility with Django 3

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -87,7 +87,7 @@ class DatabaseOperations(BasePGDatabaseOperations):
             converters.append(self.convert_uuidfield_value)
         return converters
 
-    def convert_uuidfield_value(self, value, expression, connection, context):
+    def convert_uuidfield_value(self, value, expression, connection):
         if value is not None:
             value = uuid.UUID(value)
         return value


### PR DESCRIPTION
Context removed since Django 3

Subject: Avoid errors of missing argument 'context'

### Feature or Bugfix
- Bugfix

### Purpose
- Avoid following error on Django 3:
`convert_uuidfield_value() missing 1 required positional argument: 'context'
`

### Detail
- You can reproduce the issue setting UUID field on Django 3, saving the object and then loading it again.

### Relates
- None

