### PR TITLE
Support Python 3.10, drop Django-3.0 closes #82

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.0', '3.1', '3.2']
         include:
           - django-version: 'main'
-            python-version: '3.8'
-          - django-version: 'main'
             python-version: '3.9'
+          - django-version: 'main'
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.0', '3.1', '3.2']
+        django-version: ['2.2', '3.1', '3.2']
         include:
           - django-version: 'main'
             python-version: '3.9'

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ Support versions
 
 This product is tested with:
 
-* Python-3.6, 3.7, 3.8, 3.9
+* Python-3.6, 3.7, 3.8, 3.9, 3.10
 * Django-2.2, 3.0, 3.1, 3.2
 
 License

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ Support versions
 This product is tested with:
 
 * Python-3.6, 3.7, 3.8, 3.9, 3.10
-* Django-2.2, 3.0, 3.1, 3.2
+* Django-2.2, 3.1, 3.2
 
 License
 =======

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Framework :: Django
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Programming Language :: Python :: 3.10
     Framework :: Django
     Framework :: Django :: 2.2
-    Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-dj{22,30,31,32}
+    py{36,37,38,39,310}-dj{22,31,32}
     py{39,310}-djmain
     flake8
     check
@@ -17,7 +17,6 @@ python =
 [gh-actions:env]
 DJANGO =
     2.2: dj22
-    3.0: dj30
     3.1: dj31
     3.2: dj32
     main: djmain
@@ -30,7 +29,6 @@ deps =
     pytest-cov
     mock>=2.0
     dj22: Django>=2.2,<2.3
-    dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     djmain: https://github.com/django/django/archive/main.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31,32}
-    py{38,39}-djmain
+    py{36,37,38,39,310}-dj{22,30,31,32}
+    py{39,310}-djmain
     flake8
     check
 skipsdist = True
@@ -11,7 +11,8 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, flake8, check
+    3.9: py39
+    3.10: py310, flake8, check
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- Support Python 3.10 (Oct, 2021)
- Drop Django-3.0 (EOL: April 6, 2021)

### Relates
- https://github.com/jazzband/django-redshift-backend/issues/82

