### PR TITLE
drop py2 wheel tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,8 @@ psycopg2-binary = psycopg2-binary
 psycopg2 = psycopg2
 
 [bdist_wheel]
-universal = 0  # Make the generated wheels have `py3` tag
+universal = 0
+# 0 to make the generated wheels have `py3` tag
 
 [flake8]
 max-line-length=90


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
- Drop py2 tag from wheel filename like `django_redshift_backend-2.1.0-py2.py3-none-any.whl`

### Detail
- should be `django_redshift_backend-2.1.0-py3-none-any.whl`

### Relates
- https://packaging.python.org/guides/dropping-older-python-versions/
- https://pypi.org/project/django-redshift-backend/2.1.0/#files
