### PR TITLE
Database inspection capability - fixes #13

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -588,7 +588,9 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
             column_name: (is_nullable, column_default)
             for (column_name, is_nullable, column_default) in cursor.fetchall()
         }
-        cursor.execute("SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name))
+        cursor.execute(
+            "SELECT * FROM %s LIMIT 1" % self.connection.ops.quote_name(table_name)
+        )
         return [
             FieldInfo(
                 name=column.name,
@@ -599,8 +601,8 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
                 scale=column.scale,
                 null_ok=field_map[column.name][0],
                 default=field_map[column.name][1],
-                collation=None,  # Redshift doesn't support user-defined collation sequences
-                # See https://docs.aws.amazon.com/redshift/latest/dg/c_collation_sequences.html
+                collation=None,  # Redshift doesn't support user-defined collation
+                # https://docs.aws.amazon.com/redshift/latest/dg/c_collation_sequences.html
             )
             for column in cursor.description
         ]
@@ -635,11 +637,14 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
             (conname, conkey, conrelid, contype, used_cols) in cursor.fetchall()
         ]
         table_oid = list(constraint_records)[0][2]  # Assuming at least one constraint
-        attribute_num_to_name_map = self._get_attribute_number_to_name_map_for_table(cursor, table_oid)
+        attribute_num_to_name_map = self._get_attribute_number_to_name_map_for_table(
+            cursor, table_oid)
 
         for constraint, conkey, conrelid, kind, used_cols in constraint_records:
             constraints[constraint] = {
-                "columns": [attribute_num_to_name_map[column_id_int] for column_id_int in conkey],
+                "columns": [
+                    attribute_num_to_name_map[column_id_int] for column_id_int in conkey
+                ],
                 "primary_key": kind == "p",
                 "unique": kind in ["p", "u"],
                 "foreign_key": tuple(used_cols.split(".", 1)) if kind == "f" else None,
@@ -655,7 +660,7 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
             SELECT
                 c2.relname,
                 idx.indrelid,
-                idx.indkey,  -- indkey is of type "int2vector" and returns a space-separated string
+                idx.indkey,  -- type "int2vector", returns space-separated string
                 idx.indisunique,
                 idx.indisprimary
             FROM

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -619,7 +619,7 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
         cursor.execute("""
             SELECT
                 c.conname,
-                c.conkey,
+                c.conkey::int[],
                 c.conrelid,
                 c.contype,
                 (SELECT fkc.relname || '.' || fka.attname
@@ -658,8 +658,8 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
                 idx.indkey,  -- indkey is of type "int2vector" and returns a space-separated string
                 idx.indisunique,
                 idx.indisprimary
-            FROM 
-                pg_catalog.pg_class c, 
+            FROM
+                pg_catalog.pg_class c,
                 pg_catalog.pg_class c2,
                 pg_catalog.pg_index idx
             WHERE c.oid = idx.indrelid
@@ -692,10 +692,10 @@ class DatabaseIntrospection(BasePGDatabaseIntrospection):
 
     def _get_attribute_number_to_name_map_for_table(self, cursor, table_oid):
         cursor.execute("""
-            SELECT 
-                attrelid,  -- table oid 
+            SELECT
+                attrelid,  -- table oid
                 attnum,
-                attname 
+                attname
             FROM pg_attribute
             WHERE pg_attribute.attrelid = %s
             ORDER BY attrelid, attnum;

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -176,7 +176,7 @@ class IntrospectionTest(unittest.TestCase):
     expected_constraints_query = norm_sql(
         u''' SELECT
             c.conname,
-            c.conkey,
+            c.conkey::int[],
             c.conrelid,
             c.contype,
             (SELECT fkc.relname || '.' || fka.attname
@@ -250,11 +250,13 @@ class IntrospectionTest(unittest.TestCase):
                 # conname, conkey, conrelid, contype, used_cols)
                 [('testapp_testmodel_testapp_testmodel_id_pkey', [1], 12345678, 'p', None)],
                 [
+                    # attrelid, attnum, attname
                     (12345678, 1, 'id'),
                     (12345678, 2, 'ctime'),
                     (12345678, 3, 'text'),
                     (12345678, 4, 'uuid'),
                 ],
+                # index_name, indrelid, indkey, unique, primary
                 [('testapp_testmodel_testapp_testmodel_id_pkey', 12345678, '1', True, True)],
             ]
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -199,7 +199,8 @@ class IntrospectionTest(unittest.TestCase):
         u'''SELECT
             c2.relname,
             idx.indrelid,
-            idx.indkey, -- indkey is of type "int2vector" and returns a space-separated string
+            idx.indkey,
+            -- indkey is of type "int2vector" and returns a space-separated string
             idx.indisunique,
             idx.indisprimary
         FROM
@@ -219,9 +220,13 @@ class IntrospectionTest(unittest.TestCase):
             from testapp.models import TestModel
             table_name = TestModel._meta.db_table
 
-            _table_description = conn.introspection.get_table_description(mock_cursor, table_name)
+            _ = conn.introspection.get_table_description(mock_cursor, table_name)
 
-            (select_metadata_call, fetchall_call, select_row_call) = mock_cursor.method_calls
+            (
+                select_metadata_call,
+                fetchall_call,
+                select_row_call
+            ) = mock_cursor.method_calls
 
             call_method, call_args, call_kwargs = select_metadata_call
             self.assertEqual('execute', call_method)
@@ -247,7 +252,15 @@ class IntrospectionTest(unittest.TestCase):
 
             mock_cursor.fetchall.side_effect = [
                 # conname, conkey, conrelid, contype, used_cols)
-                [('testapp_testmodel_testapp_testmodel_id_pkey', [1], 12345678, 'p', None)],
+                [
+                    (
+                        'testapp_testmodel_testapp_testmodel_id_pkey',
+                        [1],
+                        12345678,
+                        'p',
+                        None,
+                    ),
+                ],
                 [
                     # attrelid, attnum, attname
                     (12345678, 1, 'id'),
@@ -256,10 +269,19 @@ class IntrospectionTest(unittest.TestCase):
                     (12345678, 4, 'uuid'),
                 ],
                 # index_name, indrelid, indkey, unique, primary
-                [('testapp_testmodel_testapp_testmodel_id_pkey', 12345678, '1', True, True)],
+                [
+                    (
+                        'testapp_testmodel_testapp_testmodel_id_pkey',
+                        12345678,
+                        '1',
+                        True,
+                        True,
+                    ),
+                ],
             ]
 
-            table_constraints = conn.introspection.get_constraints(mock_cursor, table_name)
+            table_constraints = conn.introspection.get_constraints(
+                mock_cursor, table_name)
 
             expected_table_constraints = {
                 'testapp_testmodel_testapp_testmodel_id_pkey': {

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -9,10 +9,7 @@ from django.core.management.color import no_style
 
 
 def norm_sql(sql):
-    r = sql
-    r = r.replace(' ', '')
-    r = r.replace('\n', '')
-    return r
+    return ' '.join(sql.split()).replace('( ', '(').replace(' )', ')').replace(' ;', ';')
 
 
 class DatabaseWrapperTest(unittest.TestCase):

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -187,9 +187,9 @@ class IntrospectionTest(unittest.TestCase):
 
     expected_attributes_query = norm_sql(
         u'''SELECT
-            attrelid, -- table oid 
-            attnum, 
-            attname 
+            attrelid, -- table oid
+            attnum,
+            attname
         FROM pg_attribute
         WHERE pg_attribute.attrelid = %s
         ORDER BY attrelid, attnum;
@@ -197,18 +197,18 @@ class IntrospectionTest(unittest.TestCase):
 
     expected_indexes_query = norm_sql(
         u'''SELECT
-            c2.relname, 
-            idx.indrelid, 
+            c2.relname,
+            idx.indrelid,
             idx.indkey, -- indkey is of type "int2vector" and returns a space-separated string
-            idx.indisunique, 
-            idx.indisprimary 
-        FROM 
-            pg_catalog.pg_class c, 
-            pg_catalog.pg_class c2, 
-            pg_catalog.pg_index idx 
-        WHERE 
-            c.oid = idx.indrelid 
-            AND idx.indexrelid = c2.oid 
+            idx.indisunique,
+            idx.indisprimary
+        FROM
+            pg_catalog.pg_class c,
+            pg_catalog.pg_class c2,
+            pg_catalog.pg_index idx
+        WHERE
+            c.oid = idx.indrelid
+            AND idx.indexrelid = c2.oid
             AND c.relname = %s
     ''')
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -223,17 +223,19 @@ class IntrospectionTest(unittest.TestCase):
 
             (select_metadata_call, fetchall_call, select_row_call) = mock_cursor.method_calls
 
-            self.assertEqual('execute', select_metadata_call[0])
-            executed_sql = norm_sql(select_metadata_call.args[0])
+            call_method, call_args, call_kwargs = select_metadata_call
+            self.assertEqual('execute', call_method)
+            executed_sql = norm_sql(call_args[0])
 
             self.assertEqual(self.expected_table_description_metadata, executed_sql)
 
             self.assertNotIn('collation', executed_sql)
             self.assertNotIn('unnest', executed_sql)
 
+            call_method, call_args, call_kwargs = select_row_call
             self.assertEqual(
                 norm_sql('SELECT * FROM "testapp_testmodel" LIMIT 1'),
-                select_row_call.args[0],
+                call_args[0],
             )
 
     def test_get_get_constraints_does_not_use_unsupported_functions(self):
@@ -281,19 +283,22 @@ class IntrospectionTest(unittest.TestCase):
             self.assertEqual(expected_call_sequence, actual_call_sequence)
 
             # Constraints query
-            executed_sql = norm_sql(calls[0].args[0])
+            call_method, call_args, call_kwargs = calls[0]
+            executed_sql = norm_sql(call_args[0])
             self.assertNotIn('collation', executed_sql)
             self.assertNotIn('unnest', executed_sql)
             self.assertEqual(self.expected_constraints_query, executed_sql)
 
             # Attributes query
-            executed_sql = norm_sql(calls[2].args[0])
+            call_method, call_args, call_kwargs = calls[2]
+            executed_sql = norm_sql(call_args[0])
             self.assertNotIn('collation', executed_sql)
             self.assertNotIn('unnest', executed_sql)
             self.assertEqual(self.expected_attributes_query, executed_sql)
 
             # Indexes query
-            executed_sql = norm_sql(calls[4].args[0])
+            call_method, call_args, call_kwargs = calls[4]
+            executed_sql = norm_sql(call_args[0])
             self.assertNotIn('collation', executed_sql)
             self.assertNotIn('unnest', executed_sql)
             self.assertEqual(self.expected_indexes_query, executed_sql)

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -199,8 +199,7 @@ class IntrospectionTest(unittest.TestCase):
         u'''SELECT
             c2.relname,
             idx.indrelid,
-            idx.indkey,
-            -- indkey is of type "int2vector" and returns a space-separated string
+            idx.indkey,  -- type "int2vector", returns space-separated string
             idx.indisunique,
             idx.indisprimary
         FROM

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -80,22 +80,6 @@ expected_dml_distinct = norm_sql(
     FROM "testapp_testmodel"
 ''')
 
-expected_table_description_metadata = norm_sql(
-    u'''SELECT
-        a.attname AS column_name,
-        NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,
-        pg_get_expr(ad.adbin, ad.adrelid) AS column_default
-    FROM pg_attribute a
-    LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
-    JOIN pg_type t ON a.atttypid = t.oid
-    JOIN pg_class c ON a.attrelid = c.oid
-    JOIN pg_namespace n ON c.relnamespace = n.oid
-    WHERE c.relkind IN ('f', 'm', 'p', 'r', 'v')
-        AND c.relname = %s
-        AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
-        AND pg_catalog.pg_table_is_visible(c.oid)
-''')
-
 
 class ModelTest(unittest.TestCase):
 
@@ -173,8 +157,65 @@ class MigrationTest(unittest.TestCase):
 
 
 class IntrospectionTest(unittest.TestCase):
+    expected_table_description_metadata = norm_sql(
+        u'''SELECT
+            a.attname AS column_name,
+            NOT (a.attnotnull OR (t.typtype = 'd' AND t.typnotnull)) AS is_nullable,
+            pg_get_expr(ad.adbin, ad.adrelid) AS column_default
+        FROM pg_attribute a
+        LEFT JOIN pg_attrdef ad ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+        JOIN pg_type t ON a.atttypid = t.oid
+        JOIN pg_class c ON a.attrelid = c.oid
+        JOIN pg_namespace n ON c.relnamespace = n.oid
+        WHERE c.relkind IN ('f', 'm', 'p', 'r', 'v')
+            AND c.relname = %s
+            AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
+            AND pg_catalog.pg_table_is_visible(c.oid)
+    ''')
 
-    def test_get_table_description_does_not_use_collations(self):
+    expected_constraints_query = norm_sql(
+        u''' SELECT
+            c.conname,
+            c.conkey,
+            c.conrelid,
+            c.contype,
+            (SELECT fkc.relname || '.' || fka.attname
+            FROM pg_attribute AS fka
+            JOIN pg_class AS fkc ON fka.attrelid = fkc.oid
+            WHERE fka.attrelid = c.confrelid AND fka.attnum = c.confkey[1])
+        FROM pg_constraint AS c
+        JOIN pg_class AS cl ON c.conrelid = cl.oid
+        WHERE cl.relname = %s AND pg_catalog.pg_table_is_visible(cl.oid)
+    ''')
+
+    expected_attributes_query = norm_sql(
+        u'''SELECT
+            attrelid, -- table oid 
+            attnum, 
+            attname 
+        FROM pg_attribute
+        WHERE pg_attribute.attrelid = %s
+        ORDER BY attrelid, attnum;
+    ''')
+
+    expected_indexes_query = norm_sql(
+        u'''SELECT
+            c2.relname, 
+            idx.indrelid, 
+            idx.indkey, -- indkey is of type "int2vector" and returns a space-separated string
+            idx.indisunique, 
+            idx.indisprimary 
+        FROM 
+            pg_catalog.pg_class c, 
+            pg_catalog.pg_class c2, 
+            pg_catalog.pg_index idx 
+        WHERE 
+            c.oid = idx.indrelid 
+            AND idx.indexrelid = c2.oid 
+            AND c.relname = %s
+    ''')
+
+    def test_get_table_description_does_not_use_unsupported_functions(self):
         conn = connections['default']
         with mock.patch.object(conn, 'cursor') as mock_cursor_method:
             mock_cursor = mock_cursor_method.return_value.__enter__.return_value
@@ -188,10 +229,72 @@ class IntrospectionTest(unittest.TestCase):
             self.assertEqual('execute', select_metadata_call[0])
             executed_sql = norm_sql(select_metadata_call.args[0])
 
-            self.assertEqual(expected_table_description_metadata, executed_sql)
+            self.assertEqual(self.expected_table_description_metadata, executed_sql)
+
             self.assertNotIn('collation', executed_sql)
+            self.assertNotIn('unnest', executed_sql)
 
             self.assertEqual(
                 norm_sql('SELECT * FROM "testapp_testmodel" LIMIT 1'),
                 select_row_call.args[0],
             )
+
+    def test_get_get_constraints_does_not_use_unsupported_functions(self):
+        conn = connections['default']
+        with mock.patch.object(conn, 'cursor') as mock_cursor_method:
+            mock_cursor = mock_cursor_method.return_value.__enter__.return_value
+            from testapp.models import TestModel
+            table_name = TestModel._meta.db_table
+
+            mock_cursor.fetchall.side_effect = [
+                # conname, conkey, conrelid, contype, used_cols)
+                [('testapp_testmodel_testapp_testmodel_id_pkey', [1], 12345678, 'p', None)],
+                [
+                    (12345678, 1, 'id'),
+                    (12345678, 2, 'ctime'),
+                    (12345678, 3, 'text'),
+                    (12345678, 4, 'uuid'),
+                ],
+                [('testapp_testmodel_testapp_testmodel_id_pkey', 12345678, '1', True, True)],
+            ]
+
+            table_constraints = conn.introspection.get_constraints(mock_cursor, table_name)
+
+            expected_table_constraints = {
+                'testapp_testmodel_testapp_testmodel_id_pkey': {
+                    'columns': ['id'],
+                    'primary_key': True,
+                    'unique': True,
+                    'foreign_key': None,
+                    'check': False,
+                    'index': False,
+                    'definition': None,
+                    'options': None,
+                }
+            }
+            self.assertDictEqual(expected_table_constraints, table_constraints)
+
+            calls = mock_cursor.method_calls
+
+            # Should be a sequence of 3x execute and fetchall calls
+            expected_call_sequence = ['execute', 'fetchall'] * 3
+            actual_call_sequence = [name for (name, _args, _kwargs) in calls]
+            self.assertEqual(expected_call_sequence, actual_call_sequence)
+
+            # Constraints query
+            executed_sql = norm_sql(calls[0].args[0])
+            self.assertNotIn('collation', executed_sql)
+            self.assertNotIn('unnest', executed_sql)
+            self.assertEqual(self.expected_constraints_query, executed_sql)
+
+            # Attributes query
+            executed_sql = norm_sql(calls[2].args[0])
+            self.assertNotIn('collation', executed_sql)
+            self.assertNotIn('unnest', executed_sql)
+            self.assertEqual(self.expected_attributes_query, executed_sql)
+
+            # Indexes query
+            executed_sql = norm_sql(calls[4].args[0])
+            self.assertNotIn('collation', executed_sql)
+            self.assertNotIn('unnest', executed_sql)
+            self.assertEqual(self.expected_indexes_query, executed_sql)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-dj{31,32}
+    py{36,37,38,39,310}-dj{22,31,32}
     py{39,310}-djmain
     flake8
     check

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-dj{22,31,32}
+    py{36,37,38,39,310}-dj{31,32}
     py{39,310}-djmain
     flake8
     check


### PR DESCRIPTION
Subject: Get inspectdb working

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Purpose
- Implement database inspection methods necessary for `inspectdb` management command to work.

Redshift is based on PostgreSQL 8.x, but Django supports PostgreSQL >= 9.4, so some of the more modern features of PostgreSQL such as `unnest` and `array_agg` are not available in Redshift. Django uses some of these in the postgres backend introspection methods, so different implementations were needed to retrieve the same information from a Redshift database.

- Allow use with django-sql-explorer, which uses `get_table_description` to provide its schema view.

This has been broken since Django 3.2 introduced support for collations in the postgres backend. [Relevant commit](https://github.com/django/django/commit/e387f191f76777015b6ea687ce83cdb05ee47cee#diff-f40b4e2a6537e3ff2f6c48f600d2ec4660fee9595df87ae2aeaf22e27b5f8062)
 

### Detail
Implementation of the changes needed for `get_table_description` was straightforward, and involved removing the join to the `pg_collation` table from the SQL.

The changes required to `get_constraints`, used by `inspectdb`, were more complex. The postgres version uses `unnest`, but there is no good substitute for this function in Redshift.
Rather than attempting to build an overly complex query to achieve the same output as the postgres backend, a second query is made to the `pg_attribute` table and the join made in python. This is done twice within the `get_constraints` method, once for constraints and again for indexes.

These changes are difficult to write tests for, as the current test suite does not assume a connection to a Redshift cluster, and using a database cursor in a test requires a working database (pytest will enforce use of a `db` fixture).
The tests as written mock the cursor, but this has the disadvantage of having to hard code expected SQL and return values, which leaves the tests very brittle.

I have not attempted to implement the `orders`, `type`, `definition`, or `options` fields within `get_constraints`. I don't know where these are used or if they're necessary.

### Relates
- #13

