### PR TITLE
bug fixes and support several features for django migrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,7 +45,7 @@ Features:
 * #90, #13: Support `manage.py inspectdb`, also support working with the django-sql-explorer package.
   Thanks to Matt Fisher.
 * #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
-* #?? Support VARCHAR size changing for UNIQUE, PRIMARY KEY.
+* #?? Support VARCHAR size changing for UNIQUE, PRIMARY KEY, FOREIGN KEY.
 
 2.1.0 (2021/09/23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Features:
 
 * #82 Add Python-3.10 support.
 * #82 Drop Django-3.0 support.
+* #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
 
 2.1.0 (2021/09/23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Features:
   Thanks to Matt Fisher.
 * #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
 * #?? Support VARCHAR size changing for UNIQUE, PRIMARY KEY, FOREIGN KEY.
+* #?? Support backward migration for DROP NOT NULL column wituout DEFAULT.
+  One limitation is that the DEFAULT value is set to match the type. This is because the only way for
+  Redshift to add NOT NULL without default is to recreate the table.
 
 2.1.0 (2021/09/23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,14 @@ Incompatible Changes:
 * #??: `django_redshift_backend.distkey.DistKey` is moved to `django_redshift_backend.DistKey`.
   However old name is still supported for a compatibility.
 
+* #??: Now django-redshift-backend doesn't support `can_rollback_ddl`.
+  Originally, Redshift did not support column name changes within a transaction.
+  Please refer https://github.com/jazzband/django-redshift-backend/issues/96
+
+* #??: Changed the behavior of implicit NOT NULL column addition: When adding a NOT NULL column, it was
+  implicitly changed to allow NULL, but it is now fixed to raise a ProgrammingError exception without
+  implicitly changing it. Adding NOT NULL with no default should be an error.
+
 Bug Fixes:
 
 * #92, #93: since django-3.0 sqlmigrate (and migrate) does not work.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,14 +26,13 @@ Incompatible Changes:
   Originally, Redshift did not support column name changes within a transaction.
   Please refer https://github.com/jazzband/django-redshift-backend/issues/96
 
-* #??: Changed the behavior of implicit NOT NULL column addition: When adding a NOT NULL column, it was
-  implicitly changed to allow NULL, but it is now fixed to raise a ProgrammingError exception without
-  implicitly changing it. Adding NOT NULL with no default should be an error.
+* #??: changed the behavior of implicit not null column addition.
+  previously, adding a not null column was implicitly changed to allow null.
+  now adding not null without default raises a programmingerror exception.
 
 Bug Fixes:
 
 * #92, #93: since django-3.0 sqlmigrate (and migrate) does not work.
-* #90, #13: fix database inspection capability with `manage.py inspectdb`. Thanks to Matt Fisher.
 * #37: fix Django `contenttype` migration that cause `ProgrammingError: cannot drop sortkey column
   "name"` exception.
 * #64: fix Django `auth` migration that cause `NotSupportedError: column "content_type__app_label"
@@ -43,6 +42,8 @@ Features:
 
 * #82 Add Python-3.10 support.
 * #82 Drop Django-3.0 support.
+* #90, #13: Support `manage.py inspectdb`, also support working with the django-sql-explorer package.
+  Thanks to Matt Fisher.
 * #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
 * #?? Support VARCHAR size changing for UNIQUE, PRIMARY KEY.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,11 +9,27 @@ General:
 * #87 Drop py2 wheel tag from release package file.
 * Add `CODE_OF_CONDUCT.rst` The linked text which has been referred to from CONTRIBUTING.rst is now included.
 
+Incompatible Changes:
+
+* #??: To specify SORTKEY for Redshift, you must use `django_redshift_backend.SortKey` for
+  `Model.Meta.ordering` instead of bearer string.
+
+  **IMPORTANT**:
+  With this change, existing migration files that specify ordering are not affected.
+  If you want to apply SortKey to your migration files, please comment out the ordering option once and run
+  makemigrations, then comment in the ordering option and run makemigrations again.
+
+* #??: `django_redshift_backend.distkey.DistKey` is moved to `django_redshift_backend.DistKey`.
+  However old name is still supported for a compatibility.
 
 Bug Fixes:
 
 * #92, #93: since django-3.0 sqlmigrate (and migrate) does not work.
 * #90, #13: fix database inspection capability with `manage.py inspectdb`. Thanks to Matt Fisher.
+* #37: fix Django `contenttype` migration that cause `ProgrammingError: cannot drop sortkey column
+  "name"` exception.
+* #64: fix Django `auth` migration that cause `NotSupportedError: column "content_type__app_label"
+  specified as distkey/sortkey is not in the table "auth_permission"` exception.
 
 Features:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ Features:
 * #82 Add Python-3.10 support.
 * #82 Drop Django-3.0 support.
 * #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
+* #?? Support VARCHAR size changing for UNIQUE, PRIMARY KEY.
 
 2.1.0 (2021/09/23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ General:
 
 Incompatible Changes:
 
-* #??: To specify SORTKEY for Redshift, you must use `django_redshift_backend.SortKey` for
+* #97 To specify SORTKEY for Redshift, you must use `django_redshift_backend.SortKey` for
   `Model.Meta.ordering` instead of bearer string.
 
   **IMPORTANT**:
@@ -19,14 +19,14 @@ Incompatible Changes:
   If you want to apply SortKey to your migration files, please comment out the ordering option once and run
   makemigrations, then comment in the ordering option and run makemigrations again.
 
-* #??: `django_redshift_backend.distkey.DistKey` is moved to `django_redshift_backend.DistKey`.
+* #97 `django_redshift_backend.distkey.DistKey` is moved to `django_redshift_backend.DistKey`.
   However old name is still supported for a compatibility.
 
-* #??: Now django-redshift-backend doesn't support `can_rollback_ddl`.
+* #97 Now django-redshift-backend doesn't support `can_rollback_ddl`.
   Originally, Redshift did not support column name/type(size) changes within a transaction.
   Please refer https://github.com/jazzband/django-redshift-backend/issues/96
 
-* #??: changed the behavior of implicit not null column addition.
+* #97 changed the behavior of implicit not null column addition.
   previously, adding a not null column was implicitly changed to allow null.
   now adding not null without default raises a programmingerror exception.
 
@@ -45,8 +45,8 @@ Features:
 * #90, #13: Support `manage.py inspectdb`, also support working with the django-sql-explorer package.
   Thanks to Matt Fisher.
 * #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
-* #?? Support VARCHAR size changing for UNIQUE, PRIMARY KEY, FOREIGN KEY.
-* #?? Support backward migration for DROP NOT NULL column wituout DEFAULT.
+* #97 Support VARCHAR size changing for UNIQUE, PRIMARY KEY, FOREIGN KEY.
+* #97 Support backward migration for DROP NOT NULL column wituout DEFAULT.
   One limitation is that the DEFAULT value is set to match the type. This is because the only way for
   Redshift to add NOT NULL without default is to recreate the table.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Incompatible Changes:
   However old name is still supported for a compatibility.
 
 * #??: Now django-redshift-backend doesn't support `can_rollback_ddl`.
-  Originally, Redshift did not support column name changes within a transaction.
+  Originally, Redshift did not support column name/type(size) changes within a transaction.
   Please refer https://github.com/jazzband/django-redshift-backend/issues/96
 
 * #??: changed the behavior of implicit not null column addition.

--- a/django_redshift_backend/__init__.py
+++ b/django_redshift_backend/__init__.py
@@ -12,3 +12,5 @@ except ImportError:  # py36, py37
     except DistributionNotFound:
         # package is not installed
         pass
+
+from django_redshift_backend.meta import DistKey, SortKey  # noqa

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -14,7 +14,7 @@ import django
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db.backends.base.introspection import FieldInfo
-from django.db.backends.base.schema import _is_relevant_relation
+from django.db.backends.base.schema import _is_relevant_relation, _related_non_m2m_objects
 from django.db.backends.base.validation import BaseDatabaseValidation
 from django.db.backends.ddl_references import Statement
 from django.db.backends.postgresql.base import (
@@ -106,19 +106,6 @@ class DatabaseOperations(BasePGDatabaseOperations):
                 'DISTINCT ON fields is not supported by this database backend'
             )
         return super(DatabaseOperations, self).distinct_sql(fields, *args)
-
-
-def _related_non_m2m_objects(old_field, new_field):
-    # Filters out m2m objects from reverse relations.
-    # Returns (old_relation, new_relation) tuples.
-    return zip(
-        (obj
-         for obj in old_field.model._meta.related_objects
-         if not obj.field.many_to_many),
-        (obj
-         for obj in new_field.model._meta.related_objects
-         if not obj.field.many_to_many)
-    )
 
 
 class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -15,7 +15,9 @@ import django
 from django.conf import settings
 from django.core.exceptions import FieldDoesNotExist
 from django.db.backends.base.introspection import FieldInfo
+from django.db.backends.base.schema import _is_relevant_relation
 from django.db.backends.base.validation import BaseDatabaseValidation
+from django.db.backends.ddl_references import Statement
 from django.db.backends.postgresql.base import (
     DatabaseFeatures as BasePGDatabaseFeatures,
     DatabaseWrapper as BasePGDatabaseWrapper,
@@ -46,6 +48,7 @@ class DatabaseFeatures(BasePGDatabaseFeatures):
     has_native_uuid_field = False
     supports_aggregate_filter_clause = False
     can_rollback_ddl = False
+    supports_combined_alters = False          # since django-1.8
 
 
 class DatabaseOperations(BasePGDatabaseOperations):
@@ -122,6 +125,9 @@ def _related_non_m2m_objects(old_field, new_field):
 class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
 
     sql_create_table = "CREATE TABLE %(table)s (%(definition)s) %(options)s"
+    if django.VERSION < (3,):
+        # to remove "USING %(column)s::%(type)s"
+        sql_alter_column_type = "ALTER COLUMN %(column)s TYPE %(type)s"
 
     @property
     def multiply_varchar_length(self):
@@ -285,39 +291,52 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
         if self.connection.features.connection_persists_old_columns:
             self.connection.close()
 
+    # BASED FROM https://github.com/django/django/blob/3.2.12/django/db/backends/base/schema.py#L611-L864
     def _alter_field(self, model, old_field, new_field, old_type, new_type,
                      old_db_params, new_db_params, strict=False):
-        """Actually perform a "physical" (non-ManyToMany) field update."""
-
+        """Perform a "physical" (non-ManyToMany) field update."""
         # Drop any FK constraints, we'll remake them later
         fks_dropped = set()
-        if old_field.remote_field and old_field.db_constraint:
+        if (
+            self.connection.features.supports_foreign_keys and
+            old_field.remote_field and
+            old_field.db_constraint
+        ):
             fk_names = self._constraint_names(model, [old_field.column], foreign_key=True)
             if strict and len(fk_names) != 1:
-                raise ValueError(
-                    "Found wrong number (%s) of foreign key constraints for %s.%s" %
-                    (len(fk_names), model._meta.db_table, old_field.column))
+                raise ValueError("Found wrong number (%s) of foreign key constraints for %s.%s" % (
+                    len(fk_names),
+                    model._meta.db_table,
+                    old_field.column,
+                ))
             for fk_name in fk_names:
                 fks_dropped.add((old_field.column,))
-                self.execute(self._delete_constraint_sql(
-                    self.sql_delete_fk, model, fk_name))
+                self.execute(self._delete_fk_sql(model, fk_name))
         # Has unique been removed?
-        if (old_field.unique and
-                (not new_field.unique or
-                 (not old_field.primary_key and new_field.primary_key))):
+        if old_field.unique and (not new_field.unique or self._field_became_primary_key(old_field, new_field)):
             # Find the unique constraint for this field
+            meta_constraint_names = {constraint.name for constraint in model._meta.constraints}
             constraint_names = self._constraint_names(
-                model, [old_field.column], unique=True)
+                model, [old_field.column], unique=True, primary_key=False,
+                exclude=meta_constraint_names,
+            )
             if strict and len(constraint_names) != 1:
-                raise ValueError(
-                    "Found wrong number (%s) of unique constraints for %s.%s" %
-                    (len(constraint_names), model._meta.db_table, old_field.column))
+                raise ValueError("Found wrong number (%s) of unique constraints for %s.%s" % (
+                    len(constraint_names),
+                    model._meta.db_table,
+                    old_field.column,
+                ))
             for constraint_name in constraint_names:
-                self.execute(self._delete_constraint_sql(
-                    self.sql_delete_unique, model, constraint_name))
-        # Drop incoming FK constraints if we're a primary key and things are going
-        # to change.
-        if old_field.primary_key and new_field.primary_key and old_type != new_type:
+                self.execute(self._delete_unique_sql(model, constraint_name))
+        # Drop incoming FK constraints if the field is a primary key or unique,
+        # which might be a to_field target, and things are going to change.
+        drop_foreign_keys = (
+            self.connection.features.supports_foreign_keys and (
+                (old_field.primary_key and new_field.primary_key) or
+                (old_field.unique and new_field.unique)
+            ) and old_type != new_type
+        )
+        if drop_foreign_keys:
             # '_meta.related_field' also contains M2M reverse fields, these
             # will be filtered out
             for _old_rel, new_rel in _related_non_m2m_objects(old_field, new_field):
@@ -325,43 +344,319 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                     new_rel.related_model, [new_rel.field.column], foreign_key=True
                 )
                 for fk_name in rel_fk_names:
-                    self.execute(self._delete_constraint_sql(
-                        self.sql_delete_fk, new_rel.related_model, fk_name))
+                    self.execute(self._delete_fk_sql(new_rel.related_model, fk_name))
         # Removed an index? (no strict check, as multiple indexes are possible)
-        if (old_field.db_index and
-                not new_field.db_index and
-                not old_field.unique and
-                not (not new_field.unique and old_field.unique)):
+        # Remove indexes if db_index switched to False or a unique constraint
+        # will now be used in lieu of an index. The following lines from the
+        # truth table show all True cases; the rest are False:
+        #
+        # old_field.db_index | old_field.unique | new_field.db_index | new_field.unique
+        # ------------------------------------------------------------------------------
+        # True               | False            | False              | False
+        # True               | False            | False              | True
+        # True               | False            | True               | True
+        if old_field.db_index and not old_field.unique and (not new_field.db_index or new_field.unique):
             # Find the index for this field
-            index_names = self._constraint_names(model, [old_field.column], index=True)
+            meta_index_names = {index.name for index in model._meta.indexes}
+            # Retrieve only BTREE indexes since this is what's created with
+            # db_index=True.
+            index_names = self._constraint_names(
+                model, [old_field.column], index=True, type_=Index.suffix,
+                exclude=meta_index_names,
+            )
             for index_name in index_names:
-                self.execute(self._delete_constraint_sql(
-                    self.sql_delete_index, model, index_name))
+                # The only way to check if an index was created with
+                # db_index=True or with Index(['field'], name='foo')
+                # is to look at its name (refs #28053).
+                self.execute(self._delete_index_sql(model, index_name))
         # Change check constraints?
         if old_db_params['check'] != new_db_params['check'] and old_db_params['check']:
+            meta_constraint_names = {constraint.name for constraint in model._meta.constraints}
             constraint_names = self._constraint_names(
-                model, [old_field.column], check=True)
+                model, [old_field.column], check=True,
+                exclude=meta_constraint_names,
+            )
             if strict and len(constraint_names) != 1:
-                raise ValueError(
-                    "Found wrong number (%s) of check constraints for %s.%s" %
-                    (len(constraint_names), model._meta.db_table, old_field.column))
+                raise ValueError("Found wrong number (%s) of check constraints for %s.%s" % (
+                    len(constraint_names),
+                    model._meta.db_table,
+                    old_field.column,
+                ))
             for constraint_name in constraint_names:
-                self.execute(self._delete_constraint_sql(
-                    self.sql_delete_check, model, constraint_name))
+                self.execute(self._delete_check_sql(model, constraint_name))
         # Have they renamed the column?
         if old_field.column != new_field.column:
-            self.execute(self._rename_field_sql(
-                model._meta.db_table, old_field, new_field, new_type))
+            self.execute(self._rename_field_sql(model._meta.db_table, old_field, new_field, new_type))
+            # Rename all references to the renamed column.
+            for sql in self.deferred_sql:
+                if isinstance(sql, Statement):
+                    sql.rename_column_references(model._meta.db_table, old_field.column, new_field.column)
         # Next, start accumulating actions to do
         actions = []
+        null_actions = []
         post_actions = []
-
+        # Collation change?
+        old_collation = getattr(old_field, 'db_collation', None)
+        new_collation = getattr(new_field, 'db_collation', None)
+        if old_collation != new_collation:
+            # Collation change handles also a type change.
+            fragment = self._alter_column_collation_sql(model, new_field, new_type, new_collation)
+            actions.append(fragment)
+        # Type change?
+        elif old_type != new_type:
+            fragment, other_actions = self._alter_column_type_sql(model, old_field, new_field, new_type)
+            if fragment:  # ## Redshift: In some case, fragment will be empty.
+                actions.append(fragment)
+            post_actions.extend(other_actions)
         # When changing a column NULL constraint to NOT NULL with a given
         # default value, we need to perform 4 steps:
         #  1. Add a default for new incoming writes
         #  2. Update existing NULL rows with new default
         #  3. Replace NULL constraint with NOT NULL
         #  4. Drop the default again.
+        # Default change?
+        # ## original do alter ALTER COLUMN SET/DROP DEFAULT.
+        # ## Redshift Can't: https://github.com/jazzband/django-redshift-backend/issues/96
+        # needs_database_default = False
+        # if old_field.null and not new_field.null:
+        #     old_default = self.effective_default(old_field)
+        #     new_default = self.effective_default(new_field)
+        #     if (
+        #         not self.skip_default_on_alter(new_field) and
+        #         old_default != new_default and
+        #         new_default is not None
+        #     ):
+        #         needs_database_default = True
+        #         actions.append(self._alter_column_default_sql(model, old_field, new_field))
+
+        # Nullability change?
+        if old_field.null != new_field.null:
+            # ## original BaseDatabaseSchemaEditor._alter_column_null_sql return only a fragment
+            # fragment = self._alter_column_null_sql(model, old_field, new_field)
+            # if fragment:
+            #     null_actions.append(fragment)
+            # ## Redshift use 4 steps null alternation
+            fragment, other_actions = self._alter_column_null_sqls(model, old_field, new_field)
+            actions.append(fragment)
+            null_actions.extend(other_actions)
+
+        # Only if we have a default and there is a change from NULL to NOT NULL
+        # ## original BaseDatabaseSchemaEditor._alter_table four_way_default_alteration
+        # four_way_default_alteration = (
+        #     new_field.has_default() and
+        #     (old_field.null and not new_field.null)
+        # )
+        # ## Redshift is always 4-way, this flag should be False because the null_actions handles it.
+        four_way_default_alteration = False
+        new_default = self.effective_default(new_field)  # not used, but for flake8
+
+        if actions or null_actions:
+            if not four_way_default_alteration:
+                # If we don't have to do a 4-way default alteration we can
+                # directly run a (NOT) NULL alteration
+                actions = actions + null_actions
+            # Combine actions together if we can (e.g. postgres)
+            if self.connection.features.supports_combined_alters and actions:
+                sql, params = tuple(zip(*actions))
+                actions = [(", ".join(sql), sum(params, []))]
+            # Apply those actions
+            for sql, params in actions:
+                self.execute(
+                    # ## original assumes only alters, so adding an ALTER TABLE clause
+                    # self.sql_alter_column % {
+                    #     "table": self.quote_name(model._meta.db_table),
+                    #     "changes": sql,
+                    # },
+                    # ## Redshift executes ADD and UPDATE on alter, so the sql is a complete sentence
+                    sql,
+                    params,
+                )
+            if four_way_default_alteration:
+                # Update existing rows with default value
+                self.execute(
+                    self.sql_update_with_default % {
+                        "table": self.quote_name(model._meta.db_table),
+                        "column": self.quote_name(new_field.column),
+                        "default": "%s",
+                    },
+                    [new_default],
+                )
+                # Since we didn't run a NOT NULL change before we need to do it
+                # now
+                for sql, params in null_actions:
+                    self.execute(
+                        self.sql_alter_column % {
+                            "table": self.quote_name(model._meta.db_table),
+                            "changes": sql,
+                        },
+                        params,
+                    )
+        if post_actions:
+            for sql, params in post_actions:
+                self.execute(sql, params)
+        # If primary_key changed to False, delete the primary key constraint.
+        if old_field.primary_key and not new_field.primary_key:
+            self._delete_primary_key(model, strict)
+        # Added a unique?
+        if self._unique_should_be_added(old_field, new_field):
+            self.execute(self._create_unique_sql(model, [new_field.column]))
+        # Added an index? Add an index if db_index switched to True or a unique
+        # constraint will no longer be used in lieu of an index. The following
+        # lines from the truth table show all True cases; the rest are False:
+        #
+        # old_field.db_index | old_field.unique | new_field.db_index | new_field.unique
+        # ------------------------------------------------------------------------------
+        # False              | False            | True               | False
+        # False              | True             | True               | False
+        # True               | True             | True               | False
+
+        # ## original BasePGDatabaseSchemaEditor._alter_field has CREATE INDEX
+        # ## Redshift doesn't support it.
+        # https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-features.html
+        # if (not old_field.db_index or old_field.unique) and new_field.db_index and not new_field.unique:
+        #     self.execute(self._create_index_sql(model, fields=[new_field]))
+
+        # Type alteration on primary key? Then we need to alter the column
+        # referring to us.
+        rels_to_update = []
+        if drop_foreign_keys:
+            rels_to_update.extend(_related_non_m2m_objects(old_field, new_field))
+        # Changed to become primary key?
+        if self._field_became_primary_key(old_field, new_field):
+            # Make the new one
+            self.execute(self._create_primary_key_sql(model, new_field))
+            # Update all referencing columns
+            rels_to_update.extend(_related_non_m2m_objects(old_field, new_field))
+        # Handle our type alters on the other end of rels from the PK stuff above
+        for old_rel, new_rel in rels_to_update:
+            rel_db_params = new_rel.field.db_parameters(connection=self.connection)
+            rel_type = rel_db_params['type']
+            fragment, other_actions = self._alter_column_type_sql(
+                new_rel.related_model, old_rel.field, new_rel.field, rel_type
+            )
+            self.execute(
+                self.sql_alter_column % {
+                    "table": self.quote_name(new_rel.related_model._meta.db_table),
+                    "changes": fragment[0],
+                },
+                fragment[1],
+            )
+            for sql, params in other_actions:
+                self.execute(sql, params)
+        # Does it have a foreign key?
+        if (self.connection.features.supports_foreign_keys and new_field.remote_field and
+                (fks_dropped or not old_field.remote_field or not old_field.db_constraint) and
+                new_field.db_constraint):
+            self.execute(self._create_fk_sql(model, new_field, "_fk_%(to_table)s_%(to_column)s"))
+        # Rebuild FKs that pointed to us if we previously had to drop them
+        if drop_foreign_keys:
+            for rel in new_field.model._meta.related_objects:
+                if _is_relevant_relation(rel, new_field) and rel.field.db_constraint:
+                    self.execute(self._create_fk_sql(rel.related_model, rel.field, "_fk"))
+        # Does it have check constraints we need to add?
+        if old_db_params['check'] != new_db_params['check'] and new_db_params['check']:
+            constraint_name = self._create_index_name(model._meta.db_table, [new_field.column], suffix='_check')
+            self.execute(self._create_check_sql(model, constraint_name, new_db_params['check']))
+
+        # ## original BasePGDatabaseSchemaEditor._alter_field drop default here
+        # ## Redshift doesn't support DROP DEFAULT.
+        # Drop the default if we need to
+        # (Django usually does not use in-database defaults)
+        # if needs_database_default:
+        #     changes_sql, params = self._alter_column_default_sql(model, old_field, new_field, drop=True)
+        #     sql = self.sql_alter_column % {
+        #         "table": self.quote_name(model._meta.db_table),
+        #         "changes": changes_sql,
+        #     }
+        #     self.execute(sql, params)
+
+        # Reset connection if required
+        if self.connection.features.connection_persists_old_columns:
+            self.connection.close()
+
+    def _alter_column_with_recreate(self, model, old_field, new_field):
+        """
+        To change column type or default, We need this migration sequence:
+
+        1. Add new column with temporary name
+        2. Migrate values from original column to temprary column
+        3. Drop old column
+        4. Rename temporary column name to original column name
+        """
+        new_default = self.effective_default(new_field)
+
+        fragment = ('', [])
+        actions = []
+
+        # ## ALTER TABLE <table> ADD COLUMN 'tmp' <type> DEFAULT <value>
+        definition, params = self.column_sql(model, new_field, include_default=True)
+        new_defaults = [new_default] if new_default is not None else []
+        fragment = (
+            self.sql_create_column % {
+                "table": self.quote_name(model._meta.db_table),
+                "column": self.quote_name(new_field.column + "_tmp"),
+                "definition": definition,
+            },
+            new_defaults
+        )
+        # ## UPDATE <table> SET 'tmp' = <orig column>
+        actions.append((
+            "UPDATE %(table)s SET %(new_column)s = %(old_column)s" % {
+                "table": model._meta.db_table,
+                "new_column": self.quote_name(new_field.column + "_tmp"),
+                "old_column": self.quote_name(new_field.column),
+            }, []
+        ))
+        # ## ALTER TABLE <table> DROP COLUMN <orig column>
+        actions.append((
+            self.sql_delete_column % {
+                "table": model._meta.db_table,
+                "column": self.quote_name(new_field.column),
+            }, [],
+        ))
+        # ## ALTER TABLE <table> RENAME COLUMN 'tmp' <orig column>
+        actions.append((
+            self.sql_rename_column % {
+                "table": model._meta.db_table,
+                "old_column": self.quote_name(new_field.column + "_tmp"),
+                "new_column": self.quote_name(new_field.column),
+            }, []
+        ))
+
+        return fragment, actions
+
+    # BASED FROM https://github.com/django/django/blob/3.2.12/django/db/backends/base/schema.py#L866-L886
+    # postgres/schema.py doesn't have `_alter_column_null_sql` method.
+    def _alter_column_null_sqls(self, model, old_field, new_field):
+        """
+        Hook to specialize column null alteration.
+
+        Return a [(sql, params), ...] fragment to set a column to null or non-null
+        as required by new_field, or None if no changes are required.
+        """
+        # ## original BaseDatabaseSchemaEditor._alter_column_null_sql return a sql fragment
+        # ## Redshift needs 4 step alter
+        return self._alter_column_with_recreate(model, old_field, new_field)
+
+    # override to avoid `USING %(column)s::%(type)s` on postgres/schema.py
+    def _alter_column_type_sql(self, model, old_field, new_field, new_type):
+        # """
+        # Hook to specialize column type alteration for different backends,
+        # for cases when a creation type is different to an alteration type
+        # (e.g. SERIAL in PostgreSQL, PostGIS fields).
+
+        # Return a two-tuple of: an SQL fragment of (sql, params) to insert into
+        # an ALTER TABLE statement and a list of extra (sql, params) tuples to
+        # run once the field is altered.
+        # """
+        old_db_params = old_field.db_parameters(connection=self.connection)
+        old_type = old_db_params['type']
+        old_default = self.effective_default(old_field)
+        new_default = self.effective_default(new_field)
+
+        fragment = ('', [])
+        actions = []
+
         # Default change?
         old_default = self.effective_default(old_field)
         new_default = self.effective_default(new_field)
@@ -371,6 +666,10 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             not self.skip_default(new_field)
         )
         # column type changed (NG pattern)
+        # MEMO: for a future, another procedure to ALTER:
+        #   1. once remove UNIQUE, PKEY, FK
+        #   2. alter column
+        #   3. add UNIQUE, PKEY, FK again
         if (old_type != new_type and (
                 old_field.unique or new_field.unique or
                 old_field.primary_key or new_field.primary_key or
@@ -378,12 +677,13 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             # ## WARNING: Redshift Can't ADD/ALTER/DROP COLUMN with UNIQUE, PRIMARY KEY or FOREIGN KEY.
             # https://github.com/jazzband/django-redshift-backend/issues/96
             # https://docs.aws.amazon.com/en_us/redshift/latest/dg/r_ALTER_TABLE.html
-            fragment, other_actions = self._alter_column_type_sql(
-                model, old_field, new_field, new_type
-            )
+            _fragment = self.sql_alter_column_type % {
+                "column": self.quote_name(new_field.column),
+                "type": new_type,
+            }
             sql = self.sql_alter_column % {
                 "table": self.quote_name(model._meta.db_table),
-                "changes": fragment[0],
+                "changes": _fragment,
             }
             msg = '\n'.join([
                 "!!! WARNING: SKIPPED ALTER COLUMN SIZE WITH PRIMARY KEY, UNIQUE, FOREIGN KEY !!!",
@@ -398,6 +698,10 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             msgfmt = dict(sql=sql, o=old_field, n=new_field, otype=old_type, ntype=new_type)
             logger.warning(msg.format(**msgfmt))
             sys.stdout.write('\n\n' + msg.format(**msgfmt) + '\n\n')
+            # actions.append(['', []])
+            # self.sql_alter_column = ''  # cancel  # FIXME comment and impl
+            # FIXME: need UnitTest
+            breakpoint()
 
         # Size is changed
         elif (type(old_field) == type(new_field) and
@@ -406,153 +710,22 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
               old_field.max_length != new_field.max_length):
             # if shrink size as `old_field.max_length > new_field.max_length` and
             # larger data in database, this change will raise exception.
-            fragment, other_actions = self._alter_column_type_sql(
-                model, old_field, new_field, new_type
-            )
-            actions.append((
+            fragment = (
                 self.sql_alter_column % {
                     "table": self.quote_name(model._meta.db_table),
-                    "changes": fragment[0],
+                    "changes": self.sql_alter_column_type % {
+                        "column": self.quote_name(new_field.column),
+                        "type": new_type,
+                    }
                 },
-                fragment[1]
-            ))
+                []
+            )
 
         # Type or default is changed?
         elif (old_type != new_type) or needs_database_default:
-            # ## To change column type or default, We need this migration sequence:
-            # ##
-            # ## 1. Add new column with temporary name
-            # ## 2. Migrate values from original column to temprary column
-            # ## 3. Drop old column
-            # ## 4. Rename temporary column name to original column name
+            fragment, actions = self._alter_column_with_recreate(model, old_field, new_field)
 
-            # ## ALTER TABLE <table> ADD COLUMN 'tmp' <type> DEFAULT <value>
-            definition, params = self.column_sql(model, new_field, include_default=True)
-            new_defaults = [new_default] if new_default is not None else []
-            actions.append((
-                self.sql_create_column % {
-                    "table": self.quote_name(model._meta.db_table),
-                    "column": self.quote_name(new_field.column + "_tmp"),
-                    "definition": definition,
-                },
-                new_defaults
-            ))
-            # ## UPDATE <table> SET 'tmp' = <orig column>
-            actions.append((
-                "UPDATE %(table)s SET %(new_column)s = %(old_column)s" % {
-                    "table": model._meta.db_table,
-                    "new_column": self.quote_name(new_field.column + "_tmp"),
-                    "old_column": self.quote_name(new_field.column),
-                }, []
-            ))
-            # ## ALTER TABLE <table> DROP COLUMN <orig column>
-            actions.append((
-                self.sql_delete_column % {
-                    "table": model._meta.db_table,
-                    "column": self.quote_name(new_field.column),
-                }, [],
-            ))
-            # ## ALTER TABLE <table> RENAME COLUMN 'tmp' <orig column>
-            actions.append((
-                self.sql_rename_column % {
-                    "table": model._meta.db_table,
-                    "old_column": self.quote_name(new_field.column + "_tmp"),
-                    "new_column": self.quote_name(new_field.column),
-                }, []
-            ))
-
-        # Apply those actions
-        for sql, params in actions:
-            self.execute(sql, params)
-        if post_actions:
-            for sql, params in post_actions:
-                self.execute(sql, params)
-        # Added a unique?
-        if ((not old_field.unique and new_field.unique) or
-           (old_field.primary_key and not new_field.primary_key and new_field.unique)):
-            self.execute(self._create_unique_sql(model, [new_field.column]))
-
-        # ## original BasePGDatabaseSchemaEditor._alter_field has CREATE INDEX
-        # ## Redshift doesn't support it.
-
-        # Type alteration on primary key? Then we need to alter the column
-        # referring to us.
-        rels_to_update = []
-        if old_field.primary_key and new_field.primary_key and old_type != new_type:
-            rels_to_update.extend(_related_non_m2m_objects(old_field, new_field))
-        # Changed to become primary key?
-        # Note that we don't detect unsetting of a PK, as we assume another field
-        # will always come along and replace it.
-        if not old_field.primary_key and new_field.primary_key:
-            # First, drop the old PK
-            constraint_names = self._constraint_names(model, primary_key=True)
-            if strict and len(constraint_names) != 1:
-                raise ValueError("Found wrong number (%s) of PK constraints for %s" % (
-                    len(constraint_names),
-                    model._meta.db_table,
-                ))
-            for constraint_name in constraint_names:
-                self.execute(self._delete_constraint_sql(
-                    self.sql_delete_pk, model, constraint_name))
-            # Make the new one
-            self.execute(
-                self.sql_create_pk % {
-                    "table": self.quote_name(model._meta.db_table),
-                    "name": self.quote_name(self._create_index_name(
-                        model, [new_field.column], suffix="_pk")),
-                    "columns": self.quote_name(new_field.column),
-                }
-            )
-            # Update all referencing columns
-            rels_to_update.extend(_related_non_m2m_objects(old_field, new_field))
-        # Handle our type alters on the other end of rels from the PK stuff above
-        for old_rel, new_rel in rels_to_update:
-            rel_db_params = new_rel.field.db_parameters(connection=self.connection)
-            rel_type = rel_db_params['type']
-            fragment, other_actions = self._alter_column_type_sql(
-                new_rel.related_model._meta.db_table, old_rel.field, new_rel.field,
-                rel_type
-            )
-            self.execute(
-                self.sql_alter_column % {
-                    "table": self.quote_name(new_rel.related_model._meta.db_table),
-                    "changes": fragment[0],
-                },
-                fragment[1])
-            for sql, params in other_actions:
-                self.execute(sql, params)
-        # Does it have a foreign key?
-        if (new_field.remote_field and
-                (fks_dropped or
-                    not old_field.remote_field or
-                    not old_field.db_constraint) and
-                new_field.db_constraint):
-            self.execute(self._create_fk_sql(
-                model, new_field, "_fk_%(to_table)s_%(to_column)s"))
-        # Rebuild FKs that pointed to us if we previously had to drop them
-        if old_field.primary_key and new_field.primary_key and old_type != new_type:
-            for rel in new_field.model._meta.related_objects:
-                if not rel.many_to_many:
-                    self.execute(self._create_fk_sql(
-                        rel.related_model, rel.field, "_fk"))
-        # Does it have check constraints we need to add?
-        if old_db_params['check'] != new_db_params['check'] and new_db_params['check']:
-            self.execute(
-                self.sql_create_check % {
-                    "table": self.quote_name(model._meta.db_table),
-                    "name": self.quote_name(self._create_index_name(
-                        model, [new_field.column], suffix="_check")),
-                    "column": self.quote_name(new_field.column),
-                    "check": new_db_params['check'],
-                }
-            )
-
-        # ## original BasePGDatabaseSchemaEditor._alter_field drop default here
-        # ## Redshift doesn't support DROP DEFAULT.
-
-        # Reset connection if required
-        if self.connection.features.connection_persists_old_columns:
-            self.connection.close()
+        return fragment, actions
 
     def _get_create_options(self, model):
         """

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -46,7 +46,7 @@ class DatabaseFeatures(BasePGDatabaseFeatures):
     allows_group_by_selected_pks = False
     has_native_uuid_field = False
     supports_aggregate_filter_clause = False
-    can_rollback_ddl = False
+    can_rollback_ddl = False                  # django-redshift-backend #96
     supports_combined_alters = False          # since django-1.8
 
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -686,11 +686,21 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             not self.skip_default(new_field)
         )
 
+        # Size change?
+        def _get_max_length(field):
+            if field.is_relation:
+                max_length = field.foreign_related_fields[0].max_length
+            else:
+                max_length = field.max_length
+            return max_length
+        old_max_length = _get_max_length(old_field)
+        new_max_length = _get_max_length(new_field)
+
         # Size is changed
         if (type(old_field) == type(new_field) and
-                old_field.max_length is not None and
-                new_field.max_length is not None and
-                old_field.max_length != new_field.max_length):
+                old_max_length is not None and
+                new_max_length is not None and
+                old_max_length != new_max_length):
             # if shrink size as `old_field.max_length > new_field.max_length` and
             # larger data in database, this change will raise exception.
 

--- a/django_redshift_backend/distkey.py
+++ b/django_redshift_backend/distkey.py
@@ -1,17 +1,3 @@
-from __future__ import absolute_import
-
-from django.db.models import Index
-
-
-class DistKey(Index):
-    """A single-field index denoting the distkey for a model.
-
-    Use as follows:
-
-      class MyModel(models.Model):
-      ...
-
-      class Meta:
-          indexes = [DistKey(fields=['customer_id'])]
-    """
-    pass
+# flake8: noqa
+# for backward compatibility before 3.0.0
+from .meta import DistKey

--- a/django_redshift_backend/meta.py
+++ b/django_redshift_backend/meta.py
@@ -1,0 +1,45 @@
+from django.db.models import Index
+
+
+class DistKey(Index):
+    """A single-field index denoting the distkey for a model.
+
+    Use as follows:
+
+      class MyModel(models.Model):
+      ...
+
+      class Meta:
+          indexes = [DistKey(fields=['customer_id'])]
+    """
+    def deconstruct(self):
+        path, expressions, kwargs = super().deconstruct()
+        path = path.replace('django_redshift_backend.meta', 'django_redshift_backend')
+        return (path, expressions, kwargs)
+
+
+class SortKey(str):
+    """A SORTKEY in Redshift, also valid as ordering in Django.
+
+    https://docs.djangoproject.com/en/dev/ref/models/options/#django.db.models.Options.ordering
+
+    Use as follows:
+
+      class MyModel(models.Model):
+      ...
+
+      class Meta:
+          ordering = [SortKey('created_at'), SortKey('-id')]
+    """
+    def __hash__(self):
+        return hash(str(self))
+
+    def deconstruct(self):
+        path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
+        path = path.replace('django_redshift_backend.meta', 'django_redshift_backend')
+        return (path, [str(self)], {})
+
+    def __eq__(self, other):
+        if self.__class__ == other.__class__:
+            return self.deconstruct() == other.deconstruct()
+        return NotImplemented

--- a/doc/refs.rst
+++ b/doc/refs.rst
@@ -92,13 +92,16 @@ Django Models
 Using sortkey
 -------------
 
-There is built-in support for this option for Django >= 1.9. To use `sortkey`, simply define an `ordering` on the model meta as follow::
+There is built-in support for this option for Django >= 1.9. To use `sortkey`, define an `ordering` on the model
+meta with the custom sortkey type `django_redshift_backend.SortKey` as follow::
 
   class MyModel(models.Model):
       ...
 
       class Meta:
-          ordering = ['col2']
+          ordering = [SortKey('col2')]
+
+`SortKey` in `ordering` are also valid as ordering in Django.
 
 N.B.: there is no validation of this option, instead we let Redshift validate it for you. Be sure to refer to the `documentation <http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_examples.html>`_.
 
@@ -106,7 +109,7 @@ Using distkey
 -------------
 
 There is built-in support for this option for Django >= 1.11. To use `distkey`, define an index on the model
-meta with the custom index type `django_redshift_backend.distkey.DistKey` with `fields` naming a single field::
+meta with the custom index type `django_redshift_backend.DistKey` with `fields` naming a single field::
 
   class MyModel(models.Model):
       ...
@@ -143,7 +146,7 @@ That is, to go from::
        ...
        migrations.AddIndex(
             model_name='facttable',
-            index=django_redshift_backend.distkey.DistKey(fields=['distkeycol'], name='...'),
+            index=django_redshift_backend.DistKey(fields=['distkeycol'], name='...'),
         ),
     ]
 
@@ -160,7 +163,7 @@ To::
                 ...
             ],
             options={
-                'indexes': [django_redshift_backend.distkey.DistKey(fields=['distkeycol'], name='...')],
+                'indexes': [django_redshift_backend.DistKey(fields=['distkeycol'], name='...')],
             },
         ),
        ...

--- a/examples/proj1/testapp/models.py
+++ b/examples/proj1/testapp/models.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 
-from django_redshift_backend.base import DistKey
+from django_redshift_backend.base import DistKey, SortKey
 
 
 class TestModel(models.Model):
@@ -23,7 +23,7 @@ class TestModelWithMetaKeys(models.Model):
 
     class Meta:
         indexes = [DistKey(fields=['fk'])]
-        ordering = ['created_at', '-id']
+        ordering = [SortKey('created_at'), SortKey('-id')]
 
 
 class TestParentModel(models.Model):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,6 +12,8 @@ from test_base import OperationTestBase
 
 @pytest.mark.skipif(not os.environ.get('TEST_WITH_POSTGRES'),
                     reason='to run, TEST_WITH_POSTGRES=1 tox')
+@mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+@mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
 class MigrationTests(OperationTestBase):
     available_apps = ["testapp"]
     databases = {'default'}
@@ -38,8 +40,6 @@ class MigrationTests(OperationTestBase):
 
         print('\n'.join(collected_sql))
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_size(self):
         new_state = self.set_up_test_model('test')
         operations = [
@@ -69,8 +69,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(10);''',
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_size_for_unique(self):
         new_state = self.set_up_test_model('test')
         operations = [
@@ -96,8 +94,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE "test_pony" ADD CONSTRAINT "test_pony_name_key" UNIQUE ("name");'''
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_size_for_pk(self):
         setup_operations = [migrations.CreateModel(
             'Pony',
@@ -124,8 +120,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE "test_pony" ADD CONSTRAINT "test_pony_name_key" UNIQUE ("name");'''
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_size_for_fk(self):
         setup_operations = [
             migrations.CreateModel(
@@ -163,9 +157,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE "test_pony" ADD CONSTRAINT "test_pony_name_key" UNIQUE ("name");'''
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
-    # def test_add_notnull_without_default_change_to_nullable(self):
     def test_add_notnull_without_default_raise_exception(self):
         from django.db.utils import ProgrammingError
         new_state = self.set_up_test_model('test')
@@ -180,8 +171,6 @@ class MigrationTests(OperationTestBase):
             with self.collect_sql():
                 self.apply_operations('test', new_state, operations)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_add_notnull_with_default(self):
         new_state = self.set_up_test_model('test')
         operations = [
@@ -199,8 +188,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) DEFAULT '' NOT NULL;''',
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_type(self):
         new_state = self.set_up_test_model('test')
         operations = [
@@ -221,8 +208,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE test_pony RENAME COLUMN "weight_tmp" TO "weight";''',
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_notnull_with_default(self):
         new_state = self.set_up_test_model('test')
         operations = [
@@ -253,8 +238,6 @@ class MigrationTests(OperationTestBase):
     # ## ref: https://github.com/django/django/blob/3.2.12/django/db/backends/base/schema.py#L524
     # ## django-redshift-backend also does not support in-database defaults
     @pytest.mark.skip('django-redshift-backend does not support in-database defaults')
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_change_default(self):
         # https://github.com/jazzband/django-redshift-backend/issues/63
         new_state = self.set_up_test_model('test')
@@ -282,8 +265,6 @@ class MigrationTests(OperationTestBase):
             '''ALTER TABLE test_pony RENAME COLUMN "name_tmp" TO "name";''',
         ], sqls)
 
-    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
-    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
     def test_alter_notnull_to_nullable(self):
         # https://github.com/jazzband/django-redshift-backend/issues/63
         new_state = self.set_up_test_model('test')

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,116 @@
+import os
+from unittest import mock
+
+from django.db import connection, migrations, models
+import pytest
+
+from django_redshift_backend.base import BasePGDatabaseWrapper
+from test_base import OperationTestBase
+
+
+@pytest.mark.skipif(not os.environ.get('TEST_WITH_POSTGRES'),
+                    reason='to run, TEST_WITH_POSTGRES=1 tox')
+class MigrationTests(OperationTestBase):
+    available_apps = ["testapp"]
+    databases = {'default'}
+
+    def tearDown(self):
+        self.cleanup_test_tables()
+        # super().tearDown()  # disabled: DELETE from django_migrations
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    def test_alter_size(self):
+        new_state = self.set_up_test_model('test')
+        operations = [
+            migrations.AddField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=10, verbose_name='name'),
+            ),
+            migrations.AlterField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=20, verbose_name='name'),
+            ),
+            migrations.AlterField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=10, verbose_name='name'),
+            ),
+        ]
+        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
+        print('\n'.join(sqls))
+        sqls = [s for s in sqls if not s.startswith('--')]
+        self.assertEqual([
+            '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) NULL;''',
+            '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(20);''',
+            '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(10);''',
+        ], sqls)
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    # def test_add_notnull_without_default_change_to_nullable(self):
+    def test_add_notnull_without_default_raise_exception(self):
+        new_state = self.set_up_test_model('test')
+        operations = [
+            migrations.AddField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=10, verbose_name='name', null=False),
+            ),
+        ]
+        # sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
+        # print('\n'.join(sqls))
+        # sqls = [s for s in sqls if not s.startswith('--')]
+        # self.assertIn('''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) NULL;''', sqls)
+        with self.assertRaises(RuntimeError):
+            self.apply_operations_and_collect_sql('test', new_state, operations)
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    def test_add_notnull_with_default(self):
+        new_state = self.set_up_test_model('test')
+        operations = [
+            migrations.AddField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=10, verbose_name='name', null=False, default=''),
+            ),
+        ]
+        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
+        print('\n'.join(sqls))
+        sqls = [s for s in sqls if not s.startswith('--')]
+        self.assertEqual([
+            '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) DEFAULT '' NOT NULL;''',
+        ], sqls)
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    def test_alter_notnull_to_nullable(self):
+        # https://github.com/jazzband/django-redshift-backend/issues/63
+        new_state = self.set_up_test_model('test')
+        operations = [
+            migrations.AlterField(
+                model_name='Pony',
+                name='weight',
+                field=models.FloatField(null=True),
+            ),
+        ]
+        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
+        print('\n'.join(sqls))
+        sqls = [s for s in sqls if not s.startswith('--')]
+        self.assertEqual([
+            '''ALTER TABLE "test_pony" ADD COLUMN "name_tmp" varchar(10) NULL;''',
+            '''UPDATE "test_pony" SET "name_tmp"="name";''',
+            '''ALTER TABLE "test_pony" DROP COLUMN "name";''',
+            '''ALTER TABLE "test_pony" RENAME COLUMN "name_tmp" TO "name";''',
+        ], sqls)
+
+    def apply_operations_and_collect_sql(self, app_label, project_state, operations, atomic=True):
+        from django.db.migrations.migration import Migration
+        migration = Migration('name', app_label)
+        migration.operations = operations
+        with connection.schema_editor(collect_sql=True, atomic=atomic) as editor:
+            migration.apply(project_state, editor, collect_sql=True)
+            return editor.collected_sql

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,7 +1,9 @@
 import os
+import contextlib
 from unittest import mock
 
-from django.db import connection, migrations, models
+from django.db import migrations, models
+from django.db.migrations.state import ProjectState
 import pytest
 
 from django_redshift_backend.base import BasePGDatabaseWrapper
@@ -17,6 +19,24 @@ class MigrationTests(OperationTestBase):
     def tearDown(self):
         self.cleanup_test_tables()
         # super().tearDown()  # disabled: DELETE from django_migrations
+
+    @contextlib.contextmanager
+    def collect_sql(self):
+        collected_sql = []
+
+        def execute(self, sql, params=()):
+            sql = str(sql)
+            ending = "" if sql.endswith(";") else ";"
+            if params is not None:
+                collected_sql.append((sql % tuple(map(self.quote_value, params))) + ending)
+            else:
+                collected_sql.append(sql + ending)
+            return super(type(self), self).execute(sql, params)
+
+        with mock.patch('django_redshift_backend.base.DatabaseSchemaEditor.execute', execute):
+            yield collected_sql
+
+        print('\n'.join(collected_sql))
 
     @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
     @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
@@ -39,13 +59,108 @@ class MigrationTests(OperationTestBase):
                 field=models.CharField(max_length=10, verbose_name='name'),
             ),
         ]
-        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-        print('\n'.join(sqls))
-        sqls = [s for s in sqls if not s.startswith('--')]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
         self.assertEqual([
             '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) DEFAULT '' NOT NULL;''',
             '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(20);''',
             '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(10);''',
+        ], sqls)
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    def test_alter_size_for_unique(self):
+        new_state = self.set_up_test_model('test')
+        operations = [
+            migrations.AddField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=10, default='', unique=True),
+            ),
+            migrations.AlterField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=20, default='', unique=True),
+            ),
+        ]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
+        self.assertEqual([
+            '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) DEFAULT '' NOT NULL UNIQUE;''',
+            '''ALTER TABLE "test_pony" DROP CONSTRAINT "test_pony_name_key";''',
+            '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(20);''',
+            '''ALTER TABLE "test_pony" ADD CONSTRAINT "test_pony_name_key" UNIQUE ("name");'''
+        ], sqls)
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    def test_alter_size_for_pk(self):
+        setup_operations = [migrations.CreateModel(
+            'Pony',
+            [
+                ('name', models.CharField(max_length=10, default='', primary_key=True)),
+            ],
+        )]
+        new_state = self.apply_operations('test', ProjectState(), setup_operations)
+
+        operations = [
+            migrations.AlterField(
+                model_name='Pony',
+                name='name',
+                field=models.CharField(max_length=20, default='', primary_key=True),
+            ),
+        ]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
+        self.assertEqual([
+            '''ALTER TABLE "test_pony" DROP CONSTRAINT "test_pony_name_key";''',
+            '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(20);''',
+            '''ALTER TABLE "test_pony" ADD CONSTRAINT "test_pony_name_key" UNIQUE ("name");'''
+        ], sqls)
+
+    @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
+    @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
+    def test_alter_size_for_fk(self):
+        setup_operations = [
+            migrations.CreateModel(
+                'Pony',
+                [
+                    # ('id', models.AutoField(primary_key=True)),
+                    # ('name', models.CharField(max_length=10, unique=True)),
+                    ('id', models.CharField(max_length=10, primary_key=True)),
+                ],
+            ),
+            migrations.CreateModel(
+                'Rider',
+                [
+                    ('id', models.AutoField(primary_key=True)),
+                    ('pony', models.ForeignKey('Pony', models.CASCADE)),
+                ],
+            ),
+        ]
+        new_state = self.apply_operations('test', ProjectState(), setup_operations)
+
+        operations = [
+            migrations.AlterField(
+                model_name='Pony',
+                name='id',
+                field=models.CharField(max_length=20, primary_key=True),
+            ),
+        ]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
+        self.assertEqual([
+            '''ALTER TABLE "test_pony" DROP CONSTRAINT "test_pony_name_key";''',
+            '''ALTER TABLE "test_pony" ALTER COLUMN "name" TYPE varchar(20);''',
+            '''ALTER TABLE "test_pony" ADD CONSTRAINT "test_pony_name_key" UNIQUE ("name");'''
         ], sqls)
 
     @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
@@ -62,8 +177,8 @@ class MigrationTests(OperationTestBase):
             ),
         ]
         with self.assertRaises(ProgrammingError):
-            sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-            print(sqls)  # for debug
+            with self.collect_sql():
+                self.apply_operations('test', new_state, operations)
 
     @mock.patch('django_redshift_backend.base.DatabaseWrapper.data_types', BasePGDatabaseWrapper.data_types)
     @mock.patch('django_redshift_backend.base.DatabaseSchemaEditor._get_create_options', lambda self, model: '')
@@ -76,9 +191,10 @@ class MigrationTests(OperationTestBase):
                 field=models.CharField(max_length=10, verbose_name='name', null=False, default=''),
             ),
         ]
-        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-        print('\n'.join(sqls))
-        sqls = [s for s in sqls if not s.startswith('--')]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
         self.assertEqual([
             '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) DEFAULT '' NOT NULL;''',
         ], sqls)
@@ -94,9 +210,10 @@ class MigrationTests(OperationTestBase):
                 field=models.CharField(max_length=10, null=False, default=''),
             ),
         ]
-        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-        print('\n'.join(sqls))
-        sqls = [s for s in sqls if not s.startswith('--')]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
         self.assertEqual([
             '''ALTER TABLE "test_pony" ADD COLUMN "weight_tmp" varchar(10) DEFAULT '' NOT NULL;''',
             '''UPDATE test_pony SET "weight_tmp" = "weight";''',
@@ -120,9 +237,10 @@ class MigrationTests(OperationTestBase):
                 field=models.CharField(max_length=10, verbose_name='name', null=False, default=''),
             ),
         ]
-        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-        print('\n'.join(sqls))
-        sqls = [s for s in sqls if not s.startswith('--')]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
         self.assertEqual([
             '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) NULL;''',
             '''ALTER TABLE "test_pony" ADD COLUMN "name_tmp" varchar(10) DEFAULT '' NOT NULL;''',
@@ -152,9 +270,10 @@ class MigrationTests(OperationTestBase):
                 field=models.CharField(max_length=10, verbose_name='name', null=False, default='blink'),
             ),
         ]
-        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-        print('\n'.join(sqls))
-        sqls = [s for s in sqls if not s.startswith('--')]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
         self.assertEqual([
             '''ALTER TABLE "test_pony" ADD COLUMN "name" varchar(10) DEFAULT '' NOT NULL;''',
             '''ALTER TABLE "test_pony" ADD COLUMN "name_tmp" varchar(10) DEFAULT 'blink' NOT NULL;''',
@@ -175,20 +294,13 @@ class MigrationTests(OperationTestBase):
                 field=models.FloatField(null=True),
             ),
         ]
-        sqls = self.apply_operations_and_collect_sql('test', new_state, operations)
-        print('\n'.join(sqls))
-        sqls = [s for s in sqls if not s.startswith('--')]
+
+        with self.collect_sql() as sqls:
+            self.apply_operations('test', new_state, operations)
+
         self.assertEqual([
             '''ALTER TABLE "test_pony" ADD COLUMN "weight_tmp" double precision NULL;''',
             '''UPDATE test_pony SET "weight_tmp" = "weight";''',
             '''ALTER TABLE test_pony DROP COLUMN "weight" CASCADE;''',
             '''ALTER TABLE test_pony RENAME COLUMN "weight_tmp" TO "weight";''',
         ], sqls)
-
-    def apply_operations_and_collect_sql(self, app_label, project_state, operations, atomic=True):
-        from django.db.migrations.migration import Migration
-        migration = Migration('name', app_label)
-        migration.operations = operations
-        with connection.schema_editor(collect_sql=True, atomic=atomic) as editor:
-            migration.apply(project_state, editor, collect_sql=True)
-            return editor.collected_sql

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-import django_redshift_backend.distkey
+import django_redshift_backend
 
 
 class Migration(migrations.Migration):
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
                 ('fk', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='testapp.testreferencedmodel')),
             ],
             options={
-                'ordering': ['created_at', '-id'],
+                'ordering': [django_redshift_backend.SortKey('created_at'), django_redshift_backend.SortKey('-id')],
             },
         ),
         migrations.CreateModel(
@@ -58,6 +58,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddIndex(
             model_name='testmodelwithmetakeys',
-            index=django_redshift_backend.distkey.DistKey(fields=['fk'], name='testapp_tes_fk_id_cd99f5_idx'),
+            index=django_redshift_backend.DistKey(fields=['fk'], name='testapp_tes_fk_id_cd99f5_idx'),
         ),
     ]

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 
-from django_redshift_backend.base import DistKey
+from django_redshift_backend.base import DistKey, SortKey
 
 
 class TestModel(models.Model):
@@ -23,7 +23,7 @@ class TestModelWithMetaKeys(models.Model):
 
     class Meta:
         indexes = [DistKey(fields=['fk'])]
-        ordering = ['created_at', '-id']
+        ordering = [SortKey('created_at'), SortKey('-id')]
 
 
 class TestParentModel(models.Model):


### PR DESCRIPTION
### Feature or Bugfix
- Feature and Bugfix

### Purpose
- to support `manage.py migrate` for django auth, contenttypes, and etc.

### Detail

#### Incompatible changes

* To specify SORTKEY for Redshift, you must use `django_redshift_backend.SortKey` for
  `Model.Meta.ordering` instead of bearer string.

* `django_redshift_backend.distkey.DistKey` is moved to `django_redshift_backend.DistKey`.
  However old name is still supported for a compatibility.

* Now django-redshift-backend doesn't support `can_rollback_ddl`.
  Originally, Redshift did not support column name/type(size) changes within a transaction.
  Please refer https://github.com/jazzband/django-redshift-backend/issues/96

* changed the behavior of implicit not null column addition.
  previously, adding a not null column was implicitly changed to allow null.
  now adding not null without default raises a programmingerror exception.

#### Bug Fixes:

* #37: fix Django `contenttype` migration that cause `ProgrammingError: cannot drop sortkey column
  "name"` exception.
* #64: fix Django `auth` migration that cause `NotSupportedError: column "content_type__app_label"
  specified as distkey/sortkey is not in the table "auth_permission"` exception.

#### Features:

* #63 Support changing a field from NOT NULL to NULL on migrate / sqlmigrate.
* Support VARCHAR size changing for UNIQUE, PRIMARY KEY, FOREIGN KEY.
* Support backward migration for DROP NOT NULL column wituout DEFAULT.
  One limitation is that the DEFAULT value is set to match the type. This is because the only way for
  Redshift to add NOT NULL without default is to recreate the table.

### Relates
- #37 
- #64 
- #63 
- #96
