### PR TITLE
Removes the unsupported "ON CONFLICT DO NOTHING" clause

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -49,6 +49,7 @@ class DatabaseFeatures(BasePGDatabaseFeatures):
     has_native_uuid_field = False
     supports_aggregate_filter_clause = False
     supports_combined_alters = False          # since django-1.8
+    supports_ignore_conflicts = False
 
     # If support atomic for ddl, we should implement non-atomic migration for on rename and change type(size)
     # refs django-redshift-backend #96
@@ -112,6 +113,10 @@ class DatabaseOperations(BasePGDatabaseOperations):
                 'DISTINCT ON fields is not supported by this database backend'
             )
         return super(DatabaseOperations, self).distinct_sql(fields, *args)
+
+    def ignore_conflicts_suffix_sql(self, ignore_conflicts=None):
+        return ''
+
 
 
 def _get_type_default(field):


### PR DESCRIPTION
Subject: <short purpose of this pull request>

### Feature or Bugfix
- Bugfix

### Purpose
- This PR marks supports_ignore_conflicts as an unsupported database feature and overrides default postgres backend function so it doesn't use the unsupported "ON CONFLICT DO NOTHING" clause.

### Detail
- [Feature added](https://github.com/django/django/commit/f1fbef6cd171ddfae41fcc901f1f60ccad039f51)
- [Postgres docs](https://www.postgresql.org/docs/9.5/sql-insert.html)

### Relates
- [Issue](https://github.com/jazzband/django-redshift-backend/issues/102)

