### PR TITLE
Drop Python-3.6 and Django-2.2 support on 2022-04 #83

### DIFF
--- a/.github/workflows/test-examples-proj1.yml
+++ b/.github/workflows/test-examples-proj1.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.10']
-        django-version: ['2.2', '3.2', '4.0']
+        django-version: ['3.2', '4.0']
         include:
           - django-version: 'main'
             python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,9 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.2', '4.0']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        django-version: ['3.2', '4.0']
         exclude:
-          - django-version: '4.0'
-            python-version: '3.6'
           - django-version: '4.0'
             python-version: '3.7'
         include:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-x.y.z (Unreleased)
+4.0.0 (Unreleased)
 ------------------
 
 General:
@@ -9,6 +9,9 @@ General:
 Incompatible Changes:
 
 Features:
+
+* #83 Drop Python-3.6 support.
+* #83 Drop Django-2.2 support.
 
 Bug Fixes:
 

--- a/django_redshift_backend/__init__.py
+++ b/django_redshift_backend/__init__.py
@@ -5,7 +5,7 @@ try:  # py38 or later
     except PackageNotFoundError:
         # package is not installed
         pass
-except ImportError:  # py36, py37
+except ImportError:  # py37
     from pkg_resources import get_distribution, DistributionNotFound
     try:
         __version__ = get_distribution(__name__).version

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -741,7 +741,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             # 0. Find the unique constraint for this field
 
             unique_constraint = pk_constraint = fk_constraint = None
-            if old_field.unique and new_field.unique and not(old_field.primary_key or new_field.primary_key):
+            if old_field.unique and new_field.unique and not (old_field.primary_key or new_field.primary_key):
                 unique_constraint = self._get_constraint(model, old_field, unique=True, primary_key=False)
             elif old_field.primary_key and new_field.primary_key:
                 pk_constraint = self._get_constraint(model, old_field, primary_key=True)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,8 +43,8 @@ Support versions
 
 This product is tested with:
 
-* Python-3.6, 3.7, 3.8, 3.9, 3.10
-* Django-2.2, 3.2, 4.0
+* Python-3.7, 3.8, 3.9, 3.10
+* Django-3.2, 4.0
 
 License
 =======

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,13 +14,11 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Framework :: Django
-    Framework :: Django :: 2.2
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Intended Audience :: Developers
@@ -33,7 +31,7 @@ project_urls =
     Tracker = https://github.com/jazzband/django-redshift-backend/issues
 
 [options]
-python_requires = >=3.6, <4
+python_requires = >=3.7, <4
 packages = find:
 include_package_data = false
 zip_safe = false

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -3,7 +3,6 @@
 import os
 import unittest
 
-import django
 from django.db import connections
 from django.db.utils import NotSupportedError
 from django.core.management.color import no_style
@@ -158,16 +157,9 @@ class MigrationTest(unittest.TestCase):
                         reason='to run, TEST_WITH_POSTGRES=1 tox')
     def test_sqlmigrate(self):
         from django.db import connection
-
-        if django.VERSION < (3, 0):  # for dj22
-            from django.db.migrations.executor import MigrationExecutor
-            executor = MigrationExecutor(connection)
-            loader = executor.loader
-            collect_sql = executor.collect_sql
-        else:
-            from django.db.migrations.loader import MigrationLoader
-            loader = MigrationLoader(connection)
-            collect_sql = loader.collect_sql
+        from django.db.migrations.loader import MigrationLoader
+        loader = MigrationLoader(connection)
+        collect_sql = loader.collect_sql
 
         app_label, migration_name = 'testapp', '0001'
         migration = loader.get_migration_by_prefix(app_label, migration_name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
-    py{36,37}-dj{22,32}
-    py{38,39,310}-dj{22,32,40,main}
+    py37-dj32
+    py{38,39,310}-dj{32,40,main}
     flake8
     check
 skipsdist = True
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -16,7 +15,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    2.2: dj22
     3.2: dj32
     4.0: dj40
     main: djmain
@@ -28,7 +26,6 @@ deps =
     pytest
     pytest-cov
     mock>=2.0
-    dj22: Django>=2.2,<2.3
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
Drop Python-3.6 and Django-2.2 support on 2022-04

### Detail
- Drop Python-3.6
- Drop Django-2.2

### Relates
- #83