### PR TITLE
Fix: fix constraint creation using the wrong table and column name

### DIFF
--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -205,8 +205,8 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             params.extend(extra_params)
             # FK
             if field.remote_field and field.db_constraint:
-                to_table = field.remote_field.related_model._meta.db_table
-                to_column = field.remote_field.related_model._meta.get_field(
+                to_table = field.remote_field.model._meta.db_table
+                to_column = field.remote_field.model._meta.get_field(
                     field.remote_field.field_name).column
                 if self.connection.features.supports_foreign_keys:
                     self.deferred_sql.append(self._create_fk_sql(


### PR DESCRIPTION
Subject: Fix a bug regarding foreign key constraint creation

### Feature or Bugfix
- Bugfix

### Detail
- This was causing issue if a foreign key was pointing to another field than the remote table id

eg.

```python
Table1(models.Model):
    remote_column = models.IntegerField(unique=True)

Table2(models.Model):
    local_column = models.ForeignKey(to=Table1, to_field='remote_column')
```

During the migrations, you would get an error saying `Table2 doesn't have a column named remote_column` which is absurd since that colum is not supposed to be in that table.

