### PR TITLE
Modernize formatter: use ruff instead of flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         linter:
-          - flake8
+          - lint
           - check
 
     steps:

--- a/django_redshift_backend/__init__.py
+++ b/django_redshift_backend/__init__.py
@@ -1,5 +1,6 @@
 try:  # py38 or later
     from importlib.metadata import version, PackageNotFoundError
+
     try:
         __version__ = version("package-name")
     except PackageNotFoundError:
@@ -7,6 +8,7 @@ try:  # py38 or later
         pass
 except ImportError:  # py37
     from pkg_resources import get_distribution, DistributionNotFound
+
     try:
         __version__ = get_distribution(__name__).version
     except DistributionNotFound:

--- a/django_redshift_backend/meta.py
+++ b/django_redshift_backend/meta.py
@@ -12,9 +12,10 @@ class DistKey(Index):
       class Meta:
           indexes = [DistKey(fields=['customer_id'])]
     """
+
     def deconstruct(self):
         path, expressions, kwargs = super().deconstruct()
-        path = path.replace('django_redshift_backend.meta', 'django_redshift_backend')
+        path = path.replace("django_redshift_backend.meta", "django_redshift_backend")
         return (path, expressions, kwargs)
 
 
@@ -31,12 +32,13 @@ class SortKey(str):
       class Meta:
           ordering = [SortKey('created_at'), SortKey('-id')]
     """
+
     def __hash__(self):
         return hash(str(self))
 
     def deconstruct(self):
-        path = '%s.%s' % (self.__class__.__module__, self.__class__.__name__)
-        path = path.replace('django_redshift_backend.meta', 'django_redshift_backend')
+        path = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
+        path = path.replace("django_redshift_backend.meta", "django_redshift_backend")
         return (path, [str(self)], {})
 
     def __eq__(self, other):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py37-dj32
     py{38,39,310}-dj{32,40,main}
-    flake8
+    lint
     check
 skipsdist = True
 
@@ -11,7 +11,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, flake8, check
+    3.10: py310, lint, check
 
 [gh-actions:env]
 DJANGO =
@@ -41,15 +41,24 @@ ignore_outcome =
 ignore_errors =
     djmain: True
 
-[testenv:flake8]
+[testenv:lint]
 basepython = python3
-deps = flake8
-commands = flake8 django_redshift_backend tests
+deps=ruff
+commands=
+    ruff check django_redshift_backend
+    ruff format --check django_redshift_backend
+
+[testenv:format]
+basepython = python3
+deps=ruff
+commands=
+    ruff check --fix django_redshift_backend
+    ruff format django_redshift_backend
 
 [testenv:check]
 deps =
     twine
-    wheel
+    build
 commands =
-    python setup.py sdist bdist_wheel
+    python -m build
     twine check dist/*


### PR DESCRIPTION
modarnize internals.

- remove flake8
- add ruff

commands

- `tox -e lint` is linting
- `tox -e format` is applying format