### PR TITLE
Remove using setup.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools twine wheel
+          python -m pip install -U setuptools_scm build twine
 
       - name: Build package
         run: |
-          python setup.py --version
-          python setup.py sdist --format=gztar bdist_wheel
+          python -m build --version
+          python -m build
           twine check dist/*
 
       - name: Upload packages to Jazzband

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,19 +39,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: Cache
-      uses: actions/cache@v4
+    - uses: actions/cache@v4
       with:
-        path: ${{ steps.pip-cache.outputs.dir }}
+        path: ~/.cache/pip
         key:
-          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}-${{ hashFiles('**/tox.ini') }}
+          ${{ matrix.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ matrix.python-version }}-v1-
+          ${{ matrix.python-version }}-pip-
 
     - name: Install dependencies
       run: |

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,3 @@ LICENSE
 =======
 Apache Software License
 
-
-.. CHANGES.rst will be concatenated here by setup.py
-
-

--- a/dev-requires.txt
+++ b/dev-requires.txt
@@ -3,4 +3,5 @@ wheel
 setuptools_scm
 tox>=3.5
 build
+twine
 -e ./


### PR DESCRIPTION
- remove setup.py from GitHub actions
- remove setup.py from README
- add missing `twine` package in dev-requires.txt