### PR TITLE
remove codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,3 @@ jobs:
       env:
         DJANGO: ${{ matrix.django-version }}
         TEST_WITH_POSTGRES: 1
-
-    - name: Upload coverage
-      uses: codecov/codecov-action@v4
-      with:
-        name: Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -32,10 +32,6 @@ This is a `Amazon Redshift`_ database backend for Django_.
    :target: https://github.com/jazzband/django-redshift-backend/actions
    :alt: GitHub Actions
 
-.. image:: https://codecov.io/gh/jazzband/django-redshift-backend/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/jazzband/django-redshift-backend
-   :alt: Coverage
-
 .. image:: https://img.shields.io/github/stars/jazzband/django-redshift-backend.svg?style=social&label=Stars
    :alt: GitHub stars
    :target: https://github.com/jazzband/django-redshift-backend


### PR DESCRIPTION
- Codecov@v4 require CODECOV_TOKEN.

> Tokenless uploading is unsupported.

https://github.com/codecov/codecov-action/blob/e28ff129e5465c2c0dcc6f003fc735cb6ae0c673/README.md