### PR TITLE
[#135] Support adding BinaryType Field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Features:
 * #127 Drop Python-3.7 support.
 * #83 Drop Django-2.2 support.
 * #134 Support adding COLUMN with UNIQUE; adding column without UNIQUE then add UNIQUE CONSTRAINT.
+* #135 Support adding BinaryField.
 
 Bug Fixes:
 

--- a/django_redshift_backend/psycopg2adapter.py
+++ b/django_redshift_backend/psycopg2adapter.py
@@ -1,0 +1,10 @@
+from codecs import encode
+
+from psycopg2.extensions import Binary
+
+
+class RedshiftBinary(Binary):
+    def getquoted(self) -> bytes:
+        hex_encoded = encode(self.adapted, "hex_codec")
+        statement = b"to_varbyte('%s', 'hex')::varbyte" % hex_encoded
+        return statement

--- a/examples/dj-sql-explorer/.env.sample
+++ b/examples/dj-sql-explorer/.env.sample
@@ -1,2 +1,3 @@
 DATABASE_URL=redshift://user:password@<cluster>.<slug>.<region>.redshift.amazonaws.com:5439/<name>?DISABLE_SERVER_SIDE_CURSORS=True
 SECRET_KEY=django-insecure-key
+DEBUG=True

--- a/examples/dj-sql-explorer/config/settings.py
+++ b/examples/dj-sql-explorer/config/settings.py
@@ -139,3 +139,20 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 # django-sql-explorer
 EXPLORER_CONNECTIONS = { 'Default': 'default' }
 EXPLORER_DEFAULT_CONNECTION = 'default'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django.db.backends': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    },
+}

--- a/examples/dj-sql-explorer/requirements.txt
+++ b/examples/dj-sql-explorer/requirements.txt
@@ -1,4 +1,4 @@
-Django<4
+-e ../..[psycopg2-binary]
 django-environ==0.8.1
 django-sql-explorer
--e ../..
+python-dateutil>=2.9

--- a/examples/proj1/requirements.txt
+++ b/examples/proj1/requirements.txt
@@ -1,3 +1,2 @@
-Django<4
+-e ../..[psycopg2-binary]
 django-environ==0.8.1
--e ../..

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,10 @@ def postgres_fixture():
                 BasePGDatabaseWrapper.data_types,
             ), \
             mock.patch(
+                'django_redshift_backend.base.DatabaseSchemaEditor._modify_params_for_redshift',
+                lambda self, params: params
+            ), \
+            mock.patch(
                 'django_redshift_backend.base.DatabaseSchemaEditor._get_create_options',
                 lambda self, model: '',
             ):


### PR DESCRIPTION
- Support adding BinaryType field.
- Support forward migration with varchar to varbyte(size).
- Support backward migration from varbyte to varchar(size).
- Added BinaryType field to psycopg2 adapter.
- Testing with example/dj-sql-explorer.
