### PR TITLE
[#132] use 36 length for UUIDFields to support including hyphens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Features:
 * #83 Drop Django-2.2 support.
 * #134 Support adding COLUMN with UNIQUE; adding column without UNIQUE then add UNIQUE CONSTRAINT.
 * #135 Support adding BinaryField.
+* #132 Use 36 length for UUIDFields to support including hyphens. Thanks to kylie.
 
 Bug Fixes:
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -1105,7 +1105,7 @@ redshift_data_types = {
     "AutoField": "integer identity(1, 1)",
     "BigAutoField": "bigint identity(1, 1)",
     "TextField": "varchar(max)",  # text must be varchar(max)
-    "UUIDField": "varchar(32)",  # redshift doesn't support uuid fields
+    "UUIDField": "varchar(36)",  # redshift doesn't support uuid fields
     "BinaryField": "varbyte(%(max_length)s)",
 }
 

--- a/tests/test_redshift_backend.py
+++ b/tests/test_redshift_backend.py
@@ -25,7 +25,7 @@ expected_ddl_normal = norm_sql(
     "id" integer identity(1, 1) NOT NULL PRIMARY KEY,
     "ctime" timestamp with time zone NOT NULL,
     "text" varchar(max) NOT NULL,
-    "uuid" varchar(32) NOT NULL
+    "uuid" varchar(36) NOT NULL
 )
 ;''')
 


### PR DESCRIPTION
I created a separate PR from #133 to import only one commit.
