### PR TITLE
Bump python version support to 3.11 and 3.12 - closes #107

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         django-version: ['3.2', '4.0', '4.2']
         include:
           - django-version: 'main'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ doc/_build/
 coverage.xml
 **/.env
 examples/**/migrations/*
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310}-dj{32,40,42,main}
+    py{38,39,310,311,312}-dj{32,40,42,main}
     lint
     check
 skipsdist = True
@@ -10,6 +10,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310, lint, check
+    3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
Subject: Add python 3.11 and 3.12 to test runs
Update pyproject.toml with 3.11 and 3.12 trove classifier

### Feature
<!-- please choose -->
- Feature

### Purpose
TO have pypi display django-redshift-backend as python 3.11 and python 3.12 compatible

### Detail
- Chore as everything worked

### Relates
- #107 

