### PR TITLE
Fixed: broken django.db.backends.signals.connection_created signal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,14 +1,12 @@
 CHANGES
 =======
 
-4.2.0 (unreleased)
+4.1.1 (unreleased)
 ------------------
 
-General:
-
-Features:
-
 Bug Fixes:
+
+* Broken django.db.backends.signals.connection_created signal
 
 4.1.0 (2024/07/27)
 ------------------

--- a/django_redshift_backend/_vendor/django40/db/backends/base/base.py
+++ b/django_redshift_backend/_vendor/django40/db/backends/base/base.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import DEFAULT_DB_ALIAS, DatabaseError
 from django_redshift_backend._vendor.django40.db.backends import utils
 from django_redshift_backend._vendor.django40.db.backends.base.validation import BaseDatabaseValidation
-from django_redshift_backend._vendor.django40.db.backends.signals import connection_created
+from django.db.backends.signals import connection_created
 from django.db.transaction import TransactionManagementError
 from django.db.utils import DatabaseErrorWrapper
 from django.utils import timezone

--- a/django_redshift_backend/_vendor/django40/db/backends/signals.py
+++ b/django_redshift_backend/_vendor/django40/db/backends/signals.py
@@ -1,3 +1,0 @@
-from django.dispatch import Signal
-
-connection_created = Signal()


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Purpose
Fixed a bug that broke django.db.backends.signals.connection_created signal

### Detail
When vendoring django.db.backends in django 4.0, even singleton instances of signal were duplicated, so signals were not being sent properly

### Relates
- https://github.com/jazzband/django-redshift-backend/pull/129#discussion_r1718619507
