### PR TITLE
django-redshift-backend depends directly on psycopg2. #149

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ CHANGES
 4.2.0 (Unreleased)
 ------------------
 
+General:
+
+* #149 django-redshift-backend depends directly on psycopg2.
+  If you want to use psycopg2 pre-built packages, please refer to
+  the following site for more information: 
+  https://www.psycopg.org/docs/install.html
+
 Features:
 
 * #143 Add Django-5.0 support.

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -15,7 +15,7 @@ import json
 import django
 from django.utils import timezone
 from django.conf import settings
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Index
 from django.db.models.expressions import Col
 from django.db.utils import NotSupportedError, ProgrammingError
@@ -37,9 +37,13 @@ from ._vendor.django40.db.backends.postgresql.base import (
     DatabaseIntrospection as BasePGDatabaseIntrospection,
 )
 from .meta import DistKey, SortKey
-from psycopg2.extensions import Binary
 
-from .psycopg2adapter import RedshiftBinary
+try:
+    from psycopg2.extensions import Binary
+    from .psycopg2adapter import RedshiftBinary
+except ImportError as e:
+    raise ImproperlyConfigured("Error loading psycopg2 module: %s" % e)
+
 
 logger = logging.getLogger("django.db.backends")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,11 @@ classifiers = [
 ]
 dependencies = [
     "django<5.2",
+    "psycopg2",
     "backports.zoneinfo;python_version<'3.9'",
 ]
 
 [project.optional-dependencies]
-psycopg2 = [
-    "psycopg2",
-]
 psycopg2-binary = [
     "psycopg2-binary",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,12 @@ classifiers = [
 ]
 dependencies = [
     "django<5.2",
-    "psycopg2",
+    "psycopg2;extra!='dev'",
     "backports.zoneinfo;python_version<'3.9'",
 ]
 
 [project.optional-dependencies]
-psycopg2-binary = [
+dev = [
     "psycopg2-binary",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,19 +28,18 @@ DJANGO =
 
 [testenv]
 deps =
+    .[dev]
     coverage
     pytest
     pytest-cov
     mock>=2.0
     django-environ
-    py38: backports.zoneinfo
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
-    .[psycopg2-binary]
 setenv =
     DJANGO_SETTINGS_MODULE = settings
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ DJANGO =
 [testenv]
 deps =
     coverage
-    psycopg2-binary>=2.7
     pytest
     pytest-cov
     mock>=2.0
@@ -41,6 +40,7 @@ deps =
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
     djmain: https://github.com/django/django/archive/main.tar.gz
+    .[psycopg2-binary]
 setenv =
     DJANGO_SETTINGS_MODULE = settings
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
for #149.

Previously, django-redshift-backend would let the user choose whether to use psycopg2 or psycopg2-binary.
django-redshift-backend relies on psycopg2, so either one is required. However, if they were unaware of the option, they could create an environment where psycopg2 was not installed.
So I changed the method to change psycopg2 to a direct dependency, and if you want to select psycopg2-binary additionally, install it with `pip install django-redshift-backend[psycopg2-binary]`.