### PR TITLE
#149 Added a clear message on ImportError when the psycopg2 package cannot be found.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ CHANGES
 4.2.0 (Unreleased)
 ------------------
 
+General:
+
+* #149 Added a clear message on ImportError when the psycopg2
+  package cannot be found.
+  Please refer to the following site for more information: 
+  https://django-redshift-backend.readthedocs.io/en/master/basic.html#installation
+
 Features:
 
 * #143 Add Django-5.0 support.

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -15,10 +15,17 @@ import json
 import django
 from django.utils import timezone
 from django.conf import settings
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Index
 from django.db.models.expressions import Col
 from django.db.utils import NotSupportedError, ProgrammingError
+
+try:
+    from psycopg2.extensions import Binary
+except ImportError:
+    raise ImproperlyConfigured(
+        "Error loading psycopg2 module. Please install as: `pip install django-redshift-backend[psycopg2]` or `pip install django-redshift-backend[psycopg2-binary]`. For more information, see https://django-redshift-backend.readthedocs.io/en/master/basic.html#installation"
+    )
 
 from ._vendor.django40.db.backends.base.introspection import FieldInfo, TableInfo
 from ._vendor.django40.db.backends.base.schema import (
@@ -37,8 +44,6 @@ from ._vendor.django40.db.backends.postgresql.base import (
     DatabaseIntrospection as BasePGDatabaseIntrospection,
 )
 from .meta import DistKey, SortKey
-from psycopg2.extensions import Binary
-
 from .psycopg2adapter import RedshiftBinary
 
 logger = logging.getLogger("django.db.backends")

--- a/tox.ini
+++ b/tox.ini
@@ -28,13 +28,12 @@ DJANGO =
 
 [testenv]
 deps =
+    .[psycopg2-binary]
     coverage
-    psycopg2-binary>=2.7
     pytest
     pytest-cov
     mock>=2.0
     django-environ
-    py38: backports.zoneinfo
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj42: Django>=4.2,<5.0


### PR DESCRIPTION
Details #150.

As there is no valid way to explicitly depend on `psycopg2` at this time, the error message has been made easier to understand.

```
(venv) @shimizukawa ➜ /tmp/proj $ python
Python 3.8.19 (default, Aug 14 2024, 05:07:38) 
[Clang 18.1.8 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import django_redshift_backend.base
Traceback (most recent call last):
  File "/tmp/proj/venv/lib/python3.8/site-packages/django_redshift_backend/base.py", line 24, in <module>
    from psycopg2.extensions import Binary
ModuleNotFoundError: No module named 'psycopg2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/proj/venv/lib/python3.8/site-packages/django_redshift_backend/base.py", line 26, in <module>
    raise ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 module. Please install as: `pip install django-redshift-backend[psycopg2]` or `pip install django-redshift-backend[psycopg2-binary]`. For more information, see https://django-redshift-backend.readthedocs.io/en/master/basic.html#installation
```

`Error loading psycopg2 module. Please install as: `pip install django-redshift-backend[psycopg2]` or `pip install django-redshift-backend[psycopg2-binary]`. For more information, see https://django-redshift-backend.readthedocs.io/en/master/basic.html#installation`