### PR TITLE
Drop Django 3.2 and 4.0

### DIFF
--- a/.github/workflows/test-examples-proj1.yml
+++ b/.github/workflows/test-examples-proj1.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.10']
-        django-version: ['3.2', '4.0', '4.2', '5.0', '5.1']
+        django-version: ['4.2', '5.0', '5.1']
         include:
           - django-version: 'main'
             python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,8 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2', '4.0', '4.2', '5.0', '5.1']
+        django-version: ['4.2', '5.0', '5.1']
         exclude:
-          - python-version: '3.11'
-            django-version: '3.2'
-          - python-version: '3.12'
-            django-version: '3.2'
           - django-version: '5.0'
             python-version: '3.8'
           - django-version: '5.0'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ General:
 
 Features:
 
+* #141 Drop Django-3.2, 4.0 support.
+
 Bug Fixes:
 
 4.2.0 (2024/10/30)

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ Support versions
 This product is tested with:
 
 * Python-3.8, 3.9, 3.10, 3.11, 3.12
-* Django-3.2, 4.0, 4.2, 5.0, 5.1
+* Django-4.2, 5.0, 5.1
 
 License
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Plugins",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    py{38,39,310}-dj32
-    py{38,39,310,311,312}-dj40
     py{38,39,310,311,312}-dj42
     py{310,311,312}-dj50
     py{310,311,312}-dj51
@@ -19,8 +17,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
-    4.0: dj40
     4.2: dj42
     5.0: dj50
     5.1: dj51
@@ -34,8 +30,6 @@ deps =
     pytest-cov
     mock>=2.0
     django-environ
-    dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0,<4.1
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- drop retired django versions

### Detail
- 3.2, 4.0

### Relates
- #141

