### PR TITLE
[#142] Drop python 3.8, which will no longer be supported in 2024-10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,13 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         django-version: ['4.2', '5.0', '5.1']
         exclude:
           - django-version: '5.0'
-            python-version: '3.8'
-          - django-version: '5.0'
             python-version: '3.9'
           - django-version: '5.1'
-            python-version: '3.8'
-          - django-version: '5.1'
             python-version: '3.9'
-          - django-version: 'main'
-            python-version: '3.8'
           - django-version: 'main'
             python-version: '3.9'
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ General:
 Features:
 
 * #141 Drop Django-3.2, 4.0 support.
+* #142 Drop Python-3.8 support.
 
 Bug Fixes:
 

--- a/django_redshift_backend/base.py
+++ b/django_redshift_backend/base.py
@@ -4,8 +4,6 @@ Redshift database backend for Django based upon django PostgreSQL backend.
 Requires psycopg 2: http://initd.org/projects/psycopg2
 """
 
-from __future__ import absolute_import
-
 from copy import deepcopy
 import re
 import uuid
@@ -121,7 +119,7 @@ class DatabaseOperations(BasePGDatabaseOperations):
         return []
 
     def get_db_converters(self, expression):
-        converters = super(DatabaseOperations, self).get_db_converters(expression)
+        converters = super().get_db_converters(expression)
         internal_type = expression.output_field.get_internal_type()
         if internal_type == "UUIDField":
             converters.append(self.convert_uuidfield_value)
@@ -139,7 +137,7 @@ class DatabaseOperations(BasePGDatabaseOperations):
             raise NotSupportedError(
                 "DISTINCT ON fields is not supported by this database backend"
             )
-        return super(DatabaseOperations, self).distinct_sql(fields, *args)
+        return super().distinct_sql(fields, *args)
 
     def adapt_integerfield_value(self, value, internal_type):
         return value
@@ -278,7 +276,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             if m:
                 definition = re.sub(
                     r"varchar\((\d+?)\)",
-                    "varchar({0})".format(
+                    "varchar({})".format(
                         str(int(m.group(1)) * self.multiply_varchar_length)
                     ),
                     definition,
@@ -1058,7 +1056,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
             if isinstance(idx, DistKey):
                 if distkey:
                     raise ValueError(
-                        "Model {} has more than one DistKey.".format(model.__name__)
+                        f"Model {model.__name__} has more than one DistKey."
                     )
                 distkey = idx
         if distkey:
@@ -1072,7 +1070,7 @@ class DatabaseSchemaEditor(BasePGDatabaseSchemaEditor):
                     )
                 )
             normalized_field = quoted_column_name(distkey.fields[0])
-            create_options.append("DISTKEY({})".format(normalized_field))
+            create_options.append(f"DISTKEY({normalized_field})")
             # TODO: Support DISTSTYLE ALL.
 
         sortkeys = [
@@ -1368,7 +1366,7 @@ class DatabaseWrapper(BasePGDatabaseWrapper):
     data_types.update(redshift_data_types)
 
     def __init__(self, *args, **kwargs):
-        super(DatabaseWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.atomic_blocks = []
         self.features = DatabaseFeatures(self)

--- a/django_redshift_backend/meta.py
+++ b/django_redshift_backend/meta.py
@@ -37,7 +37,7 @@ class SortKey(str):
         return hash(str(self))
 
     def deconstruct(self):
-        path = "%s.%s" % (self.__class__.__module__, self.__class__.__name__)
+        path = "{}.{}".format(self.__class__.__module__, self.__class__.__name__)
         path = path.replace("django_redshift_backend.meta", "django_redshift_backend")
         return (path, [str(self)], {})
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ Support versions
 
 This product is tested with:
 
-* Python-3.8, 3.9, 3.10, 3.11, 3.12
+* Python-3.9, 3.10, 3.11, 3.12
 * Django-4.2, 5.0, 5.1
 
 License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "Redshift database backend for Django"
 readme = "README.rst"
 license = {file = "LICENSE"}
-requires-python = ">=3.8, <4"
+requires-python = ">=3.9, <4"
 authors = [
     { name = "shimizukawa", email = "shimizukawa@gmail.com" },
 ]
@@ -23,7 +23,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-dj42
+    py{39,310,311,312}-dj42
     py{310,311,312}-dj50
     py{310,311,312}-dj51
     lint
@@ -9,7 +9,6 @@ skipsdist = True
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310, lint, check
     3.11: py311


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Purpose
- drop old versions

### Detail
- remove py3.8 support

### Relates
- #142