### PR TITLE
Add configuration for testing compatibility with Django 5.2

### DIFF
--- a/.github/workflows/test-examples-proj1.yml
+++ b/.github/workflows/test-examples-proj1.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.10']
-        django-version: ['4.2', '5.0', '5.1']
+        django-version: ['4.2', '5.0', '5.1', '5.2']
         include:
           - django-version: 'main'
             python-version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,13 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        django-version: ['4.2', '5.0', '5.1']
+        django-version: ['4.2', '5.0', '5.1', '5.2']
         exclude:
           - django-version: '5.0'
             python-version: '3.9'
           - django-version: '5.1'
+            python-version: '3.9'
+          - django-version: '5.2'
             python-version: '3.9'
           - django-version: 'main'
             python-version: '3.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -31,7 +32,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "django<5.2",
+    "django<6.0",
     "backports.zoneinfo;python_version<'3.9'",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{39,310,311,312}-dj42
     py{310,311,312}-dj50
     py{310,311,312,313}-dj51
+    py{310,311,312,313}-dj52
     lint
     check
 skipsdist = True
@@ -20,6 +21,7 @@ DJANGO =
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
     main: djmain
 
 [testenv]
@@ -33,6 +35,7 @@ deps =
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
     dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<6.0
     djmain: https://github.com/django/django/archive/main.tar.gz
 setenv =
     DJANGO_SETTINGS_MODULE = settings


### PR DESCRIPTION
Django 5.2

### Feature or Bugfix
- Bugfix

### Purpose
Add testing support for Django 5.2

### Detail
- Update `tox` config
- Update Test GitHub Actions matrix
- Update Example project GitHub Action matrix
- Update `pyproject.toml` to require Django < 6

### Relates
Aims to address #168